### PR TITLE
Return offers from flight search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The application integrates with the Amadeus Flight API for real flight searches.
 - Supabase Secrets: same three values must be added to Edge Function Secrets
 - Rate limit: The Amadeus API has rate limits of approximately 1 request/second, 50 requests/minute
 - Throttling & retry logic is built into our implementation
+- Date range for test environment: when `AMADEUS_BASE_URL` points to the test API, only travel dates in 2025-2026 are accepted. The `flight-search` function adjusts out-of-range dates automatically, but results may be limited.
 
 ### Retry Logic
 The application implements exponential backoff for API requests:


### PR DESCRIPTION
## Summary
- collect saved offers inside `flight-search` edge function
- include offers and pagination in the response
- document Amadeus test date limits

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b3f21fc58832aa2a2cd78dddc7607