### PR TITLE
Add setup script for Codex

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install Node dependencies using pnpm
+corepack enable pnpm
+pnpm install --frozen-lockfile
+
+# Install Playwright browsers if Playwright is used
+if grep -q '@playwright/test' package.json; then
+  npx playwright install --with-deps
+fi

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ cd <repository-name>
 ```bash
 pnpm install
 ```
+   - In the Codex environment this step is performed automatically by `.codex/setup.sh` during setup.
 
 3. Create a `.env` file from the example:
 ```bash


### PR DESCRIPTION
## Summary
- install dependencies at container setup via `.codex/setup.sh`
- mention automated install in README

## Testing
- `npm test` *(fails: vitest not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b5b529064832aaa7459aadc1d2eb1