### PR TITLE
Fix TripOffers query param without binary diff

### DIFF
--- a/src/pages/TripOffers.tsx
+++ b/src/pages/TripOffers.tsx
@@ -27,7 +27,8 @@ interface TripDetails {
 
 export default function TripOffers() {
   const [searchParams] = useSearchParams();
-  const tripId = searchParams.get("id");
+  // Support both legacy `tripRequestId` and new `id` query param names
+  const tripId = searchParams.get("id") || searchParams.get("tripRequestId");
   const location = useLocation();
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Notes
- Reverted unintended `bun.lockb` changes from previous commit
- TripOffers page now accepts both `id` and legacy `tripRequestId` query parameters

## Testing
- `npm test` *(fails: multiple tests failing)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683b8c2786e8832a8804faf19c7d6549