### PR TITLE
Relax flight number validation, remove extraneous lockfile

### DIFF
--- a/src/services/tripOffersService.ts
+++ b/src/services/tripOffersService.ts
@@ -22,7 +22,9 @@ const MAX_PAGE_SIZE = 100;
 const MIN_PRICE = 1;
 const MAX_PRICE = 100000; // $100k as sanity check
 const AIRLINE_CODE_REGEX = /^[A-Z0-9]{2,3}$/;
-const FLIGHT_NUMBER_REGEX = /^[A-Z0-9]{2,3}\d{1,4}[A-Z]?$/;
+// Flight numbers returned by the edge function are numeric without the airline
+// prefix (e.g. "1234"), so allow 1-4 digits with an optional trailing letter.
+const FLIGHT_NUMBER_REGEX = /^\d{1,4}[A-Z]?$/;
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/;
 

--- a/supabase/functions/flight-search/flightApi.edge.ts
+++ b/supabase/functions/flight-search/flightApi.edge.ts
@@ -2,7 +2,26 @@
 // This file is specifically for Supabase Edge Functions
 // It contains Deno-specific code that shouldn't be imported by client-side code
 
-import type { TablesInsert } from "../../../src/integrations/supabase/types";
+// Supabase type for inserting into the flight_offers table.  Defined here to
+// avoid importing from the src directory which isn't available in the Deno
+// runtime used by Edge Functions.
+export interface FlightOfferInsert {
+  airline: string;
+  auto_book?: boolean;
+  booking_url?: string | null;
+  created_at?: string;
+  departure_date: string;
+  departure_time: string;
+  duration: string;
+  flight_number: string;
+  id?: string;
+  layover_airports?: string[] | null;
+  price: number;
+  return_date: string;
+  return_time: string;
+  stops?: number;
+  trip_request_id: string;
+}
 
 export interface FlightSearchParams {
   origin: string[];
@@ -137,7 +156,7 @@ async function withRetry<T>(
 export async function searchOffers(
   params: FlightSearchParams,
   tripRequestId: string
-): Promise<TablesInsert<"flight_offers">[]> {
+): Promise<FlightOfferInsert[]> {
   console.log(`[flight-search] Starting searchOffers for trip ${tripRequestId}`);
   
   const startTime = Date.now();
@@ -986,7 +1005,7 @@ function dedupOffers(allOffers: any[]): any[] {
 }
 
 // Transform Amadeus response to our format with detailed diagnostics
-export function transformAmadeusToOffers(api: any, tripRequestId: string, params?: FlightSearchParams): TablesInsert<"flight_offers">[] {
+export function transformAmadeusToOffers(api: any, tripRequestId: string, params?: FlightSearchParams): FlightOfferInsert[] {
   // Handle empty response
   if (!api.data || !Array.isArray(api.data) || api.data.length === 0) {
     console.log("[flight-search] No data to transform");


### PR DESCRIPTION
## Summary
- relax `FLIGHT_NUMBER_REGEX` so numeric-only flight numbers pass validation
- inline flight offer types for edge function and use them throughout
- remove `bun.lock`

## Testing
- `npm test --silent` *(fails: multiple Vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_683c79009704832a95514576ac99c5c9