### PR TITLE
fix: enable strictNullChecks to support exactOptionalPropertyTypes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "noImplicitAny": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,
-    "allowJs": true,
-    "noUnusedLocals": false,
-    "strictNullChecks": false
+            "allowJs": true,
+            "noUnusedLocals": false,
+            "strictNullChecks": true
   }
 }


### PR DESCRIPTION
Updated tsconfig.json to enable strictNullChecks, making it compatible with exactOptionalPropertyTypes in tsconfig.app.json