### PR TITLE
Fix duration validation

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -7,8 +7,12 @@ import type { Database } from './types';
 // Make sure to add these to your .env.local file:
 // VITE_SUPABASE_URL=your_supabase_url
 // VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
-const SUPABASE_URL = import.meta.env['VITE_SUPABASE_URL'] as string;
-const SUPABASE_ANON_KEY = import.meta.env['VITE_SUPABASE_ANON_KEY'] as string;
+const SUPABASE_URL = import.meta.env['VITE_SUPABASE_URL'];
+const SUPABASE_ANON_KEY = import.meta.env['VITE_SUPABASE_ANON_KEY'];
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('Missing Supabase environment variables');
+}
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/pages/TripOffers.tsx
+++ b/src/pages/TripOffers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { fetchTripOffers, Offer } from "@/services/tripOffersService";

--- a/src/services/tripOffersService.ts
+++ b/src/services/tripOffersService.ts
@@ -86,8 +86,8 @@ function isValidFlightNumber(flightNumber: string): boolean {
 // Validate duration format (e.g., "2h 30m" or "PT4H15M")
 export function isValidDuration(duration: string): boolean {
   // Accept both human-readable and ISO 8601 duration formats
-  const isoPattern = /^PT((\d+H)?(\d+M)?|\d+[HMS])$/;  // PT4H15M, PT4H, PT15M
-  const humanPattern = /^\d+h(?:\s*\d+m)?$/;           // 4h 15m, 4h
+  const isoPattern = /^PT(?=\d)(?:\d+H)?(?:\d+M)?$/; // PT4H15M, PT4H, PT15M
+  const humanPattern = /^\d+h(?:\s*\d+m)?$/;          // 4h 15m, 4h
   
   // Check if it matches either format but ensure at least one time component exists
   if (isoPattern.test(duration)) {


### PR DESCRIPTION
## Notes
- Removed unused React import from TripOffers page
- Added environment variable checks for Supabase client
- Updated duration regex to accept ISO 8601 durations like `PT4H15M`

## Testing
- `bun run test` *(fails: Terminating worker thread, missing env vars)*
- `bun x tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683c959c3770832ab9f3e00400725829