### PR TITLE
Fix: Correct onSelect prop signature for Calendar component

### DIFF
--- a/src/components/TripRequestForm.tsx
+++ b/src/components/TripRequestForm.tsx
@@ -298,7 +298,7 @@ const TripRequestForm = ({ tripRequestId }: TripRequestFormProps) => {
             mode="range"
             defaultMonth={dateRange?.from}
             selected={dateRange}
-            onSelect={onDateRangeChange}
+            onSelect={(range, _selectedDay, _activeModifiers, _e) => onDateRangeChange(range)}
             numberOfMonths={2}
             pagedNavigation
             className="border-0 rounded-md"


### PR DESCRIPTION
The onSelect prop of the Calendar component (which uses react-day-picker) in "range" mode expects a handler with multiple arguments (range, selectedDay, activeModifiers, event). However, the setDateRange state setter function used as the handler only expects a single argument (the date range).

This commit adapts the onSelect handler in TripRequestForm.tsx to an inline arrow function that correctly receives all arguments from the DayPicker but only passes the necessary 'range' argument to the setDateRange function. This resolves the TypeScript type error related to the onSelect prop signature.