### PR TITLE
Add booking_url to OfferProps interface

### DIFF
--- a/src/components/trip/TripOfferCard.tsx
+++ b/src/components/trip/TripOfferCard.tsx
@@ -16,6 +16,7 @@ export interface OfferProps {
   return_date: string;
   return_time: string;
   duration: string;
+  booking_url?: string;
 }
 
 const TripOfferCard = ({ offer }: { offer: OfferProps }) => {


### PR DESCRIPTION
This change introduces an optional `booking_url` field to the `OfferProps` interface in `src/components/trip/TripOfferCard.tsx`.

This prepares the data structure for future integration of external booking links. No mock data files were explicitly modified as none were found directly associated with this component during the exploration phase; the optional nature of the field serves as a placeholder.