### PR TITLE
feat: Implement external booking flow and update interfaces

### DIFF
--- a/src/components/trip/TripOfferCard.tsx
+++ b/src/components/trip/TripOfferCard.tsx
@@ -2,7 +2,7 @@
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { PlaneTakeoff, Calendar, Clock } from "lucide-react";
+import { PlaneTakeoff, Calendar, Clock, ExternalLink } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
 import { useNavigate } from "react-router-dom";
 
@@ -16,15 +16,26 @@ export interface OfferProps {
   return_date: string;
   return_time: string;
   duration: string;
+  booking_url?: string;
 }
 
 const TripOfferCard = ({ offer }: { offer: OfferProps }) => {
   const navigate = useNavigate();
 
   const handleSelect = () => {
-    console.log('Selected offer', offer.id);
-    
-    // Create query parameters from the offer
+    if (offer.booking_url) {
+      console.log(`External booking link clicked for offer ID: ${offer.id}, URL: ${offer.booking_url}`);
+      console.log('Opening external booking URL:', offer.booking_url);
+      window.open(offer.booking_url, '_blank');
+      toast({
+        title: "Redirecting to Airline",
+        description: `You are being redirected to ${offer.airline} to complete your booking.`,
+      });
+      return;
+    }
+
+    // Current logic for internal booking
+    console.log('Selected offer for internal booking:', offer.id);
     const params = new URLSearchParams();
     params.set('id', offer.id);
     params.set('airline', offer.airline);
@@ -36,12 +47,11 @@ const TripOfferCard = ({ offer }: { offer: OfferProps }) => {
     params.set('return_time', offer.return_time);
     params.set('duration', offer.duration);
     
-    // Navigate to confirm page with offer details in query string
     navigate(`/trip/confirm?${params.toString()}`);
     
     toast({
       title: "Flight Selected",
-      description: `You've selected ${offer.airline} flight ${offer.flight_number}`,
+      description: `You've selected ${offer.airline} flight ${offer.flight_number} for internal review.`,
     });
   };
 
@@ -91,7 +101,8 @@ const TripOfferCard = ({ offer }: { offer: OfferProps }) => {
           <p className="text-3xl font-bold mb-2">${offer.price}</p>
           <p className="text-sm text-gray-500 mb-4">Round trip per person</p>
           <Button className="w-full md:w-auto" onClick={handleSelect}>
-            Select This Flight
+            {offer.booking_url ? `Book on ${offer.airline}` : "Select This Flight"}
+            {offer.booking_url && <ExternalLink className="ml-2 h-4 w-4" />}
           </Button>
         </div>
       </div>

--- a/supabase/functions/flight-search/flightApi.edge.ts
+++ b/supabase/functions/flight-search/flightApi.edge.ts
@@ -567,6 +567,8 @@ export function transformAmadeusToOffers(api: any, tripRequestId: string): Table
         const retDate = new Date(returnDate);
         const tripDays = Math.round((retDate.getTime() - outDate.getTime()) / (1000 * 60 * 60 * 24));
         
+        const bookingLink = offer.pricingOptions?.agents?.[0]?.deepLink || offer.deepLink || null;
+
         return [{
           trip_request_id: tripRequestId,
           airline: out.carrierCode,
@@ -577,6 +579,7 @@ export function transformAmadeusToOffers(api: any, tripRequestId: string): Table
           return_time: back.departure.at.split("T")[1].slice(0,5),
           duration: offer.itineraries[0].duration,
           price: parseFloat(offer.price.total),
+          booking_url: bookingLink,
         }];
       } catch (err) {
         console.error("[flight-search] Error transforming individual offer:", err);


### PR DESCRIPTION
This commit introduces a Google Flights-style external booking flow for manual flight searches, while preserving the existing auto-booking functionality. It also includes fixes for initial build errors.

Changes include:

1.  **Build Error Fixes (Phase 1):**
    *   Corrected Calendar component prop types in `TripRequestForm.tsx`.
    *   Updated `BookingRequest` interface in `Dashboard.tsx` to use `error_message`.
    *   Removed `user_id` from `booking_requests` insert in `TripConfirm.tsx`.
    *   Verified `TripRequestResult` interface in `src/types/form.ts`.

2.  **Flight Data & Interface Updates (Phase 2):**
    *   Added `booking_url?: string` to the `OfferProps` interface in `TripOfferCard.tsx`.
    *   Updated the `transformAmadeusToOffers` function in `supabase/functions/flight-search/flightApi.edge.ts` to extract and include `booking_url` from Amadeus API responses into the `flight_offers` data. The database schema already supported this field.

3.  **Manual Booking Flow Transformation (Phase 3):**
    *   Modified `TripOfferCard.tsx`:
        *   Button text now dynamically changes to "Book on [Airline]" if `booking_url` is present.
        *   An external link icon is displayed on the button for external bookings.
        *   Clicking the button opens `booking_url` in a new tab.
        *   If `booking_url` is absent, the card falls back to the original internal booking flow via `/trip/confirm`.
    *   Added basic `console.log` click tracking for external booking links.

4.  **Auto-Booking Preservation (Phase 4):**
    *   Reviewed auto-booking logic (`auto-book/index.ts`) and related components. Confirmed that the introduction of `booking_url` and changes to the manual flow in `TripOfferCard` do not interfere with the backend-driven auto-booking process.

5.  **Manual Flow Cleanup (Phase 5 - Partial):
    *   Verified that `TripConfirm.tsx` is correctly bypassed for offers with a `booking_url`, serving its purpose for the internal fallback flow without needing immediate modification for this part of the plan.

This work sets the foundation for the new external booking experience for manual searches. Next steps involve further cleanup of the manual flow and UX enhancements as outlined in the plan.