### PR TITLE
feat: Implement booking cancellation and refund workflow

### DIFF
--- a/supabase/functions/cancel-booking/index.ts
+++ b/supabase/functions/cancel-booking/index.ts
@@ -1,12 +1,22 @@
 // supabase/functions/cancel-booking/index.ts
 
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
-// import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'; // If needed for actual cancellation logic
-// import { cancelAmadeusOrder } from '../lib/amadeus.ts'; // If Amadeus cancellation is involved
-// import { stripe } from '../lib/stripe.ts'; // If Stripe refund is involved
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getAmadeusAccessToken, cancelAmadeusOrder } from '../lib/amadeus.ts'; // HTTP Helpers
+import { stripe } from '../lib/stripe.ts'; // Stripe SDK instance (assuming stripe.ts exports it)
 
-// Helper function to get Supabase admin client (if needed for fetching booking details)
-// const getSupabaseAdmin = () => { ... };
+// Helper function to get Supabase admin client
+const getSupabaseAdmin = () => {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    console.error('[CancelBooking] CRITICAL: Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY env vars.');
+    throw new Error('Server configuration error: Supabase credentials missing.');
+  }
+  return createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { persistSession: false }
+  });
+};
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*', // Adjust for production
@@ -19,108 +29,155 @@ serve(async (req: Request) => {
     return new Response('ok', { headers: corsHeaders });
   }
 
-  // TODO: Implement actual booking cancellation logic here.
-  // This would involve:
-  // 1. Identifying the booking to cancel (e.g., from req.json() payload like { booking_id, user_id }).
-  // 2. Authenticating/Authorizing the user.
-  // 3. Performing cancellation with third-party providers (e.g., Amadeus using cancelAmadeusOrder).
-  // 4. Issuing refunds (e.g., Stripe using stripe.refunds.create).
-  // 5. Updating database status in 'bookings' and 'trip_requests' tables.
+  let bookingId: string | null = null;
+  let authenticatedUserId: string | null = null;
+  const supabaseAdmin = getSupabaseAdmin();
+  // For invoking send-notification
+  const supabaseUrlForInvoke = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKeyForInvoke = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
-  // For now, this is a stub that simulates a successful cancellation for notification purposes.
-
-  let user_id: string | null = null;
-  let booking_id: string | null = null;
-  let pnr: string | null = null;
-  let cancellation_reason: string = 'User requested cancellation.'; // Example reason
 
   try {
-    // Simulate extracting data from request - in a real scenario, this would come from req.json()
-    // Also, ensure user making the request is authorized to cancel this booking_id.
-    const body = await req.json().catch(() => ({})); // Gracefully handle if no body / not json
-    user_id = body.user_id || 'mock_user_id_for_notification_stub'; // Replace with actual user_id from authenticated user or request
-    booking_id = body.booking_id || 'mock_booking_id_for_notification_stub';
-    pnr = body.pnr || 'MOCKPNR';
-    if (body.reason) cancellation_reason = body.reason;
+    // 1. Get Authenticated User ID (from JWT)
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return new Response(JSON.stringify({ error: 'Missing or invalid Authorization header' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(token);
+    if (userError || !user) {
+      console.warn('[CancelBooking] Auth error or no user from token:', userError?.message);
+      return new Response(JSON.stringify({ error: 'Authentication failed or user not found' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+    authenticatedUserId = user.id;
+    console.log(`[CancelBooking] Authenticated user: ${authenticatedUserId}`);
 
-    console.log(`[CancelBookingStub] Received request to cancel booking: ${booking_id} for user: ${user_id}`);
+    // 2. Get booking_id from request payload
+    const body = await req.json().catch(() => ({})); // Handle non-JSON body gracefully
+    bookingId = body.booking_id;
+    if (!bookingId || typeof bookingId !== 'string') {
+      return new Response(JSON.stringify({ error: 'Missing or invalid booking_id in request body' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+    console.log(`[CancelBooking] Received request to cancel booking_id: ${bookingId}`);
 
-    // ---- START: TODO: Actual Cancellation Logic Placeholder ----
-    // Example:
-    // const { data: bookingToCancel, error: fetchError } = await supabaseAdmin.from('bookings').select('*, user_id, pnr, amadeus_order_id, payment_intent_id_from_payments_table').eq('id', booking_id).single();
-    // if (fetchError || !bookingToCancel) throw new Error('Booking not found');
-    // if (bookingToCancel.user_id !== authenticated_user_id) throw new Error('Unauthorized');
-    // if (bookingToCancel.amadeus_order_id) {
-    //    const token = await getAmadeusAccessToken();
-    //    const amadeusCancelResult = await cancelAmadeusOrder(bookingToCancel.amadeus_order_id, token);
-    //    if (!amadeusCancelResult.success) throw new Error('Amadeus cancellation failed.');
-    // }
-    // if (bookingToCancel.payment_intent_id_from_payments_table) {
-    //    await stripe.refunds.create({ payment_intent: bookingToCancel.payment_intent_id_from_payments_table, reason: 'requested_by_customer' });
-    // }
-    // await supabaseAdmin.from('bookings').update({ status: 'canceled', cancellation_reason: cancellation_reason }).eq('id', booking_id);
-    // user_id = bookingToCancel.user_id; // Use actual user_id from fetched booking
-    // pnr = bookingToCancel.pnr; // Use actual PNR
-    const actualCancellationSuccess = true; // Assume cancellation was successful for this stub
-    console.log(`[CancelBookingStub] STUB: Actual booking cancellation logic for ${booking_id} would go here.`);
-    // ---- END: TODO: Actual Cancellation Logic Placeholder ----
+    // 3. Fetch Booking & Validate Eligibility
+    const { data: booking, error: fetchBookingError } = await supabaseAdmin
+      .from('bookings')
+      .select('id, pnr, user_id, status, created_at, trip_request_id, amadeus_order_id') // Added amadeus_order_id
+      .eq('id', bookingId)
+      .single();
 
-    if (actualCancellationSuccess && user_id) {
-      // Invoke send-notification
-      const supabaseUrl = Deno.env.get('SUPABASE_URL');
-      const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-
-      if (supabaseUrl && serviceRoleKey) {
-        const sendNotificationUrl = `${supabaseUrl}/functions/v1/send-notification`;
-        const notificationPayload = {
-          booking_id: booking_id,
-          pnr: pnr,
-          reason: cancellation_reason,
-          // Add other relevant details from the actual booking if fetched
-        };
-
-        console.log(`[CancelBookingStub] Invoking send-notification for booking_canceled. Booking ID: ${booking_id}, User ID: ${user_id}`);
-        // Fire-and-forget
-        fetch(sendNotificationUrl, {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${serviceRoleKey}`,
-            'Content-Type': 'application/json',
-            'apikey': serviceRoleKey
-          },
-          body: JSON.stringify({
-            user_id: user_id, // Ensure this is the correct user_id associated with the booking
-            type: 'booking_canceled',
-            payload: notificationPayload
-          })
-        }).then(async res => {
-          if (!res.ok) {
-            const errorText = await res.text().catch(() => 'Could not parse error response.');
-            console.error('[CancelBookingStub] send-notification call failed:', res.status, errorText);
-          } else {
-            console.log('[CancelBookingStub] send-notification for booking_canceled invoked successfully.');
-          }
-        }).catch(err => console.error('[CancelBookingStub] Error invoking send-notification:', err.message));
-      } else {
-        console.warn('[CancelBookingStub] SUPABASE_URL or SERVICE_ROLE_KEY not configured. Cannot send notification.');
-      }
-
-      return new Response(JSON.stringify({ success: true, message: `Booking ${booking_id} cancellation processed (stub). Notification triggered.` }), {
-        status: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
-    } else if (!actualCancellationSuccess) {
-        console.error(`[CancelBookingStub] Simulated cancellation failure for booking: ${booking_id}`);
-        throw new Error('Simulated cancellation failure.');
-    } else { // actualCancellationSuccess is true but user_id is missing
-        console.error(`[CancelBookingStub] User ID missing for booking: ${booking_id}, cannot send notification.`);
-        throw new Error('User ID missing, cannot send notification.');
+    if (fetchBookingError) {
+      console.error(`[CancelBooking] Error fetching booking ${bookingId}:`, fetchBookingError.message);
+      return new Response(JSON.stringify({ error: 'Booking not found or database error' }), { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+    if (!booking) { // Should be caught by fetchBookingError with .single(), but good practice
+      return new Response(JSON.stringify({ error: 'Booking not found' }), { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
+    if (booking.user_id !== authenticatedUserId) {
+      console.warn(`[CancelBooking] User ${authenticatedUserId} unauthorized to cancel booking ${bookingId} owned by ${booking.user_id}.`);
+      return new Response(JSON.stringify({ error: 'Unauthorized to cancel this booking' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
+    if (booking.status !== 'ticketed' && booking.status !== 'booked') { // Allow 'booked' or 'ticketed'
+      console.log(`[CancelBooking] Booking ${bookingId} not in a cancelable status (current: ${booking.status}).`);
+      return new Response(JSON.stringify({ error: `Booking is not in a cancelable state (status: ${booking.status})` }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
+    const twentyFourHoursInMs = 24 * 60 * 60 * 1000;
+    const bookingCreatedAt = new Date(booking.created_at).getTime();
+    const now = Date.now();
+    if (now - bookingCreatedAt > twentyFourHoursInMs) {
+      console.log(`[CancelBooking] Booking ${bookingId} created at ${booking.created_at} is outside the 24-hour cancellation window.`);
+      return new Response(JSON.stringify({ error: 'Cancellation window has passed (must be within 24 hours of booking)' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+    console.log(`[CancelBooking] Booking ${bookingId} is eligible for cancellation.`);
+
+    // 4. Amadeus Cancellation (use amadeus_order_id if available, fallback to pnr)
+    const orderIdToCancelWithAmadeus = booking.amadeus_order_id || booking.pnr;
+    if (!orderIdToCancelWithAmadeus) {
+        console.error(`[CancelBooking] Booking ${bookingId} is missing Amadeus Order ID (or PNR to use as such). Cannot proceed with Amadeus cancellation.`);
+        throw new Error('Booking Amadeus Order ID/PNR is missing, cannot cancel with Amadeus.');
+    }
+
+    console.log(`[CancelBooking] Attempting Amadeus cancellation for Amadeus Order ID: ${orderIdToCancelWithAmadeus}`);
+    const amadeusToken = await getAmadeusAccessToken();
+    if (!amadeusToken) throw new Error('Failed to get Amadeus access token for cancellation.');
+
+    const amadeusCancelResult = await cancelAmadeusOrder(orderIdToCancelWithAmadeus, amadeusToken);
+    if (!amadeusCancelResult.success) {
+      console.error(`[CancelBooking] Amadeus cancellation failed for Order ID ${orderIdToCancelWithAmadeus}: ${amadeusCancelResult.error}`);
+      throw new Error(`Amadeus cancellation failed: ${amadeusCancelResult.error || 'Unknown Amadeus error'}`);
+    }
+    console.log(`[CancelBooking] Amadeus cancellation successful for Order ID ${orderIdToCancelWithAmadeus}`);
+
+    // 5. Stripe Refund
+    console.log(`[CancelBooking] Attempting Stripe refund for booking ${bookingId}`);
+    const { data: paymentRow, error: fetchPaymentError } = await supabaseAdmin
+      .from('payments')
+      .select('stripe_payment_intent_id')
+      .eq('booking_id', bookingId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (fetchPaymentError || !paymentRow || !paymentRow.stripe_payment_intent_id) {
+      console.error(`[CancelBooking] Could not find Stripe PaymentIntent ID for booking ${bookingId}. Error: ${fetchPaymentError?.message || 'No payment record or PI ID'}`);
+      throw new Error(`Stripe PaymentIntent ID not found for booking ${bookingId}. Amadeus order was cancelled. Manual refund check required.`);
+    }
+    const intentId = paymentRow.stripe_payment_intent_id;
+    console.log(`[CancelBooking] Found Stripe PaymentIntent ID: ${intentId}. Proceeding with refund.`);
+
+    await stripe.refunds.create({
+        payment_intent: intentId,
+        reason: 'requested_by_customer'
+    });
+    console.log(`[CancelBooking] Stripe refund initiated for PaymentIntent ID: ${intentId}`);
+
+    // 6. Update Database
+    console.log(`[CancelBooking] Updating database records for booking ${bookingId}`);
+    const nowISO = new Date().toISOString();
+    const { error: updateBookingError } = await supabaseAdmin
+      .from('bookings')
+      .update({ status: 'canceled', updated_at: nowISO, cancellation_reason: 'user_requested_within_24h' })
+      .eq('id', bookingId);
+    if (updateBookingError) throw new Error(`Failed to update booking status: ${updateBookingError.message}`);
+
+    const { error: updatePaymentError } = await supabaseAdmin
+      .from('payments')
+      .update({ status: 'refunded', updated_at: nowISO })
+      .eq('stripe_payment_intent_id', intentId);
+    if (updatePaymentError) console.warn(`[CancelBooking] Failed to update payment status to refunded for PI ${intentId}: ${updatePaymentError.message}`); // Log as warning, main cancellation succeeded.
+    console.log(`[CancelBooking] Database records updated for booking ${bookingId} to canceled/refunded.`);
+
+    // 7. Send Cancellation Notification
+    if (supabaseUrlForInvoke && serviceRoleKeyForInvoke && booking.user_id) {
+      const sendNotificationUrl = `${supabaseUrlForInvoke}/functions/v1/send-notification`;
+      const notificationPayload = {
+        booking_id: booking.id,
+        pnr: booking.pnr, // Use the actual PNR from the booking record for notification
+        trip_request_id: booking.trip_request_id,
+        reason: 'Your booking was successfully canceled and refunded as per your request within the 24-hour window.',
+      };
+      fetch(sendNotificationUrl, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${serviceRoleKeyForInvoke}`, 'Content-Type': 'application/json', 'apikey': serviceRoleKeyForInvoke },
+          body: JSON.stringify({ user_id: booking.user_id, type: 'booking_canceled', payload: notificationPayload })
+      })
+      .then(async res => res.ok ? console.log('[CancelBooking] Cancellation notification sent.') : res.text().then(txt => console.error('[CancelBooking] Failed to send cancellation notification:', res.status, txt)))
+      .catch(err => console.error('[CancelBooking] Error sending cancellation notification:', err.message));
+    }
+
+    return new Response(JSON.stringify({ success: true, message: 'Booking canceled and refund initiated successfully.' }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+
   } catch (error) {
-    console.error(`[CancelBookingStub] Error processing cancellation for booking ${booking_id}: ${error.message}`, error);
-    return new Response(JSON.stringify({ error: error.message, booking_id: booking_id, note: "This is a stub implementation." }), {
-      status: 500,
+    console.error(`[CancelBooking] Error processing cancellation for booking ${bookingId || 'unknown'}: ${error.message}`, error.stack);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: (error.message.includes('Unauthorized') ? 403 : (error.message.includes('not found') ? 404 : (error.message.includes('cancelable state') || error.message.includes('window has passed') || error.message.includes('Missing booking_id') ? 400 : 500))),
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }

--- a/supabase/functions/tests/cancel-booking.test.ts
+++ b/supabase/functions/tests/cancel-booking.test.ts
@@ -1,0 +1,243 @@
+// supabase/functions/tests/cancel-booking.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach, MockedFunction, SpyInstance } from 'vitest';
+
+// --- Mock Deno.env.get ---
+const originalDeno = globalThis.Deno;
+const mockEnvGet = vi.fn();
+vi.stubGlobal('Deno', {
+  ...originalDeno,
+  env: { get: mockEnvGet },
+});
+
+// --- Mock Supabase Client ---
+const mockSupabaseSingle = vi.fn();
+const mockSupabaseUpdateResult = vi.fn(); // To control outcome of .update().eq()
+const mockSupabaseUpdateEq = vi.fn(() => mockSupabaseUpdateResult);
+const mockSupabaseFromChainedMethods = {
+  select: vi.fn().mockReturnThis(),
+  update: vi.fn(() => ({ eq: mockSupabaseUpdateEq })),
+  eq: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: mockSupabaseSingle,
+};
+const mockSupabaseAuthGetUser = vi.fn();
+const mockSupabaseClientInstance = {
+  from: vi.fn((_tableName: string) => mockSupabaseFromChainedMethods),
+  auth: { getUser: mockSupabaseAuthGetUser },
+};
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => mockSupabaseClientInstance),
+}));
+
+// --- Mock Amadeus Helpers ---
+const mockGetAmadeusAccessToken = vi.fn();
+const mockCancelAmadeusOrder = vi.fn();
+vi.mock('../lib/amadeus.ts', () => ({
+  getAmadeusAccessToken: mockGetAmadeusAccessToken,
+  cancelAmadeusOrder: mockCancelAmadeusOrder,
+}));
+
+// --- Mock Stripe SDK ---
+const mockStripeRefundsCreate = vi.fn();
+vi.mock('../lib/stripe.ts', () => ({ // Assuming stripe.ts exports the initialized client as 'stripe'
+  stripe: { refunds: { create: mockStripeRefundsCreate } },
+}));
+
+// --- Mock global fetch for send-notification ---
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// --- Test Suite ---
+describe('cancel-booking Edge Function', () => {
+  let cancelBookingHandler: (req: Request) => Promise<Response>;
+  let consoleErrorSpy: SpyInstance, consoleLogSpy: SpyInstance, consoleWarnSpy: SpyInstance;
+
+  const mockBookingId = 'booking_id_cancel_123';
+  const mockUserId = 'user_auth_abc';
+  const mockAmadeusOrderId = 'AMADEUS_ORDER_ID_XYZ'; // Assuming this is stored in booking.pnr or booking.amadeus_order_id
+  const mockTripRequestId = 'trip_req_cancel_789';
+  const mockStripePiId = 'pi_stripe_mock_cancel';
+
+  const mockEligibleBooking = {
+    id: mockBookingId,
+    pnr: 'PNR_FALLBACK', // Fallback if amadeus_order_id is not present
+    amadeus_order_id: mockAmadeusOrderId, // Preferred field for Amadeus Order ID
+    user_id: mockUserId,
+    status: 'ticketed',
+    created_at: new Date().toISOString(), // Assumes current time is within 24h
+    trip_request_id: mockTripRequestId,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockEnvGet.mockImplementation((key: string) => {
+      if (key === 'SUPABASE_URL') return 'http://mock-supabase.url';
+      if (key === 'SUPABASE_SERVICE_ROLE_KEY') return 'mock-service-role-key';
+      return undefined;
+    });
+
+    mockSupabaseAuthGetUser.mockResolvedValue({ data: { user: { id: mockUserId } }, error: null });
+    mockSupabaseSingle.mockImplementation((_chainedCall?: any) => {
+        const lastFromCall = mockSupabaseClientInstance.from.mock.calls.slice(-1)[0]?.[0];
+        if (lastFromCall === 'bookings') return Promise.resolve({ data: mockEligibleBooking, error: null });
+        if (lastFromCall === 'payments') return Promise.resolve({ data: { stripe_payment_intent_id: mockStripePiId }, error: null });
+        return Promise.resolve({ data: null, error: new Error('Supabase mock: Unhandled "from" table in .single()')});
+    });
+    mockSupabaseUpdateResult.mockResolvedValue({ error: null }); // Default successful DB update
+
+    mockGetAmadeusAccessToken.mockResolvedValue('mock-amadeus-access-token');
+    mockCancelAmadeusOrder.mockResolvedValue({ success: true });
+    mockStripeRefundsCreate.mockResolvedValue({ id: 're_stripe_mock_refund', status: 'succeeded' });
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const module = await import('../cancel-booking/index.ts');
+    cancelBookingHandler = (module as any).testableHandler ||
+        (module as any).default?.handler ||
+        (async (_req: Request) => new Response("Handler not found in module", { status: 501 }));
+    if (cancelBookingHandler.toString().includes("Handler not found in module")) {
+        console.warn("Test setup: Could not get testableHandler from cancel-booking/index.ts.");
+    }
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  const createMockCancelRequest = (body: any, token = 'mock-jwt') =>
+    new Request('http://localhost/cancel-booking', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify(body),
+    });
+
+  it('1. Successfully cancels a booking and issues refund', async () => {
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseBody.success).toBe(true);
+    expect(responseBody.message).toContain('Booking canceled and refund initiated successfully.');
+    expect(mockGetAmadeusAccessToken).toHaveBeenCalled();
+    expect(mockCancelAmadeusOrder).toHaveBeenCalledWith(mockAmadeusOrderId, 'mock-amadeus-access-token');
+    expect(mockStripeRefundsCreate).toHaveBeenCalledWith({ payment_intent: mockStripePiId, reason: 'requested_by_customer' });
+    expect(mockSupabaseUpdateEq).toHaveBeenCalledTimes(2); // bookings and payments
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/send-notification'), expect.objectContaining({
+        body: expect.stringContaining('"type":"booking_canceled"')
+    }));
+  });
+
+  it('2a. Returns 400 if booking status is not "ticketed" or "booked"', async () => {
+    mockSupabaseSingle.mockResolvedValueOnce({ data: { ...mockEligibleBooking, status: 'pending_payment' }, error: null });
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: expect.stringContaining("not in a cancelable state") }));
+  });
+
+  it('2b. Returns 400 if booking is older than 24 hours', async () => {
+    const oldDate = new Date(Date.now() - (25 * 60 * 60 * 1000)).toISOString();
+    mockSupabaseSingle.mockResolvedValueOnce({ data: { ...mockEligibleBooking, created_at: oldDate }, error: null });
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Cancellation window has passed' }));
+  });
+
+  it('3. Returns 403 for authorization failure (user_id mismatch)', async () => {
+    mockSupabaseSingle.mockResolvedValueOnce({ data: { ...mockEligibleBooking, user_id: 'another-user-id' }, error: null });
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Unauthorized to cancel this booking' }));
+  });
+
+  it('4. Returns 404 if booking not found', async () => {
+    mockSupabaseSingle.mockResolvedValueOnce({ data: null, error: null }); // No booking found
+    const request = createMockCancelRequest({ booking_id: 'non_existent_booking' });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Booking not found' }));
+  });
+
+  it('5. Returns 500 if getAmadeusAccessToken fails', async () => {
+    mockGetAmadeusAccessToken.mockResolvedValueOnce(null);
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Failed to get Amadeus access token' }));
+  });
+
+  it('6. Returns 500 if Amadeus cancelAmadeusOrder fails', async () => {
+    mockCancelAmadeusOrder.mockResolvedValueOnce({ success: false, error: 'Amadeus system down' });
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Amadeus cancellation failed: Amadeus system down' }));
+  });
+
+  it('7. Returns 500 if Stripe PaymentIntent ID not found', async () => {
+    mockSupabaseSingle.mockImplementation((_chainedCall?: any) => { // Override for this test
+        const lastFromCall = mockSupabaseClientInstance.from.mock.calls.slice(-1)[0]?.[0];
+        if (lastFromCall === 'bookings') return Promise.resolve({ data: mockEligibleBooking, error: null });
+        if (lastFromCall === 'payments') return Promise.resolve({ data: null, error: null }); // PI not found
+        return Promise.resolve({ data: null, error: new Error('Supabase mock: Unhandled "from" table in .single()')});
+    });
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: expect.stringContaining('Stripe PaymentIntent ID not found') }));
+  });
+
+  it('8. Returns 500 if Stripe refunds.create fails', async () => {
+    mockStripeRefundsCreate.mockRejectedValueOnce(new Error('Stripe refund error'));
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Stripe refund error' }));
+  });
+
+  it('9. Returns 500 if bookings table update fails', async () => {
+    mockSupabaseUpdateResult.mockResolvedValueOnce({ error: new Error('Bookings DB update failed') }); // First update is bookings
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Failed to update booking status: Bookings DB update failed' }));
+  });
+
+  it('10. Returns 400 if booking_id is missing in request', async () => {
+    const request = createMockCancelRequest({}); // Empty body
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Missing or invalid booking_id' }));
+  });
+
+  it('11. Returns 401 for authentication failure', async () => {
+    mockSupabaseAuthGetUser.mockResolvedValueOnce({ data: { user: null }, error: { message: 'Invalid token' } });
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    const response = await cancelBookingHandler(request);
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'Authentication failed or user not found' }));
+  });
+
+  it('12. send-notification is called on successful cancellation', async () => {
+    // This is covered by test case 1, but can be a specific check too
+    const request = createMockCancelRequest({ booking_id: mockBookingId });
+    await cancelBookingHandler(request);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://mock-supabase.url/functions/v1/send-notification',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining(`"type":"booking_canceled"`),
+      })
+    );
+  });
+});


### PR DESCRIPTION
I've introduced a feature allowing you to cancel confirmed bookings within 24 hours and receive an automated refund. This involves a new Edge Function for backend processing and conceptual changes for the frontend.

Key changes include:

1.  **`supabase/functions/cancel-booking/index.ts` (New Edge Function)**:
    *   Accepts a `booking_id` via POST request.
    *   Authenticates you using JWT and authorizes against the booking's `user_id`.
    *   Validates booking eligibility: status must be 'ticketed' (or equivalent confirmed/paid status) and `created_at` must be within the last 24 hours.
    *   Performs Amadeus flight cancellation using the HTTP helper `cancelAmadeusOrder(orderId, token)` from `lib/amadeus.ts` (uses `booking.pnr` or `booking.amadeus_order_id` as the Amadeus Order ID).
    *   Initiates a Stripe refund using `stripe.refunds.create({ payment_intent: intentId })` after fetching the `stripe_payment_intent_id` from the `payments` table.
    *   Updates database statuses:
        *   `bookings` table: sets `status` to 'canceled'.
        *   `payments` table: sets `status` to 'refunded'.
    *   Triggers a 'booking_canceled' notification via the `send-notification` function.
    *   Includes robust error handling for each step.

2.  **`src/pages/TripConfirm.tsx` (Conceptual Frontend Changes)**:
    *   Detailed guidance provided for adding a "Cancel Booking" button, visible only for eligible bookings.
    *   Workflow includes a user confirmation modal.
    *   On confirmation, `fetch` POSTs to the `/functions/v1/cancel-booking` endpoint.
    *   UI should update based on success or failure of the cancellation request.

3.  **Supporting Libraries**:
    *   Utilizes existing HTTP helpers in `lib/amadeus.ts` for Amadeus interactions (token, cancellation).
    *   Utilizes the existing Stripe SDK instance in `lib/stripe.ts` for refunds.

4.  **Database (Assumptions & Requirements)**:
    *   `bookings` table: Must have accurate `status` (e.g., 'ticketed'), `created_at`, `user_id`, and `pnr` (or `amadeus_order_id`). Status updated to 'canceled'.
    *   `payments` table: Must link to `bookings` via `booking_id` and store `stripe_payment_intent_id`. Status updated to 'refunded'.

5.  **Unit Tests (`supabase/functions/tests/cancel-booking.test.ts`)**:
    *   I've added comprehensive tests for the `cancel-booking` Edge Function, covering various success scenarios, eligibility checks, authorization, external API failures (Amadeus, Stripe), database update failures, and input validation. Dependencies are mocked.
    *   Conceptual updates for front-end tests in `TripConfirm.test.tsx` were outlined.

This feature provides you with self-service cancellation within the allowed window, automating the necessary backend processes.