### PR TITLE
feat(auto-book): Add payment_captured flag for idempotency

### DIFF
--- a/supabase/migrations/20250604120000_add_payment_captured_to_booking_requests.sql
+++ b/supabase/migrations/20250604120000_add_payment_captured_to_booking_requests.sql
@@ -1,0 +1,6 @@
+-- Add payment_captured column to booking_requests table
+-- This flag helps prevent double-charging or double-booking in auto-book scenarios.
+ALTER TABLE public.booking_requests
+ADD COLUMN IF NOT EXISTS payment_captured BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN public.booking_requests.payment_captured IS 'Flag to indicate if the payment for this booking request has been successfully captured. Used for idempotency in auto-booking.';


### PR DESCRIPTION
I've introduced a `payment_captured` flag in the `booking_requests` table to enhance idempotency in the `auto-book/index.ts` function. This prevents double-charging or double-booking if `auto-book` processes a trip request that already has a corresponding payment captured via a `booking_requests` record.

Key changes include:

1.  **Database Migration**:
    *   I added migration `supabase/migrations/20250604120000_add_payment_captured_to_booking_requests.sql` to add the `payment_captured BOOLEAN NOT NULL DEFAULT FALSE` column to the `public.booking_requests` table.

2.  **`supabase/functions/auto-book/index.ts` Modifications**:
    *   **Early Check**: Before initiating Amadeus or Stripe calls (but after lock acquisition), I now query the `booking_requests` table for any record matching the current `trip.id` (as `trip_request_id`) and `status: 'pending_payment'`.
        *   If such a record is found and its `payment_captured` flag is `true`, I log this and exit gracefully, preventing further processing. The `booking_attempts` record for the current run is marked appropriately.
        *   If a record is found with `payment_captured = false`, its ID (`associatedBookingRequestId`) is stored.
    *   **Update Flag Post-Capture**: Immediately after a successful Stripe payment capture, if an `associatedBookingRequestId` was identified, I update the corresponding `booking_requests` record to set `payment_captured = true` and update its status (e.g., to `processing_after_payment`).
    *   **Critical Error Handling**: If this update to `booking_requests.payment_captured` fails after Stripe has captured the payment, an error is thrown. This error is caught by the main `catch` block, which then attempts to refund the Stripe payment and cancel the Amadeus booking if one was made.

This enhancement improves the robustness of the auto-booking process when interacting with potentially pre-existing `booking_requests` that might have already undergone payment.