### PR TITLE
Fix: Restore flight search result rendering

### DIFF
--- a/src/hooks/useTripOffers.ts
+++ b/src/hooks/useTripOffers.ts
@@ -144,6 +144,7 @@ export const useTripOffers = ({ tripId, initialTripDetails }: UseTripOffersProps
       const flightSearchPayload: FlightSearchRequestBody = {
         tripRequestId: tripId,
         relaxedCriteria: relaxCriteriaArg,
+        destination_location_code: currentTripDetails.destination_airport || "",
       };
       const searchServiceResponse: FlightSearchResponse = await invokeFlightSearch(flightSearchPayload);
 

--- a/src/services/api/flightSearchApi.ts
+++ b/src/services/api/flightSearchApi.ts
@@ -13,6 +13,8 @@ export interface FlightSearchRequestBody {
   tripRequestId: string;
   /** Whether to use relaxed criteria for the search. */
   relaxedCriteria: boolean;
+  /** The destination airport code (e.g., LAX). */
+  destination_location_code: string;
 }
 
 /**


### PR DESCRIPTION
The flight search functionality was not rendering offers because the Edge Function was expecting `destination_location_code` in its payload, but the frontend was sending `destination_airport`.

This commit addresses the issue by:
1. Updating the `FlightSearchRequestBody` interface in `src/services/api/flightSearchApi.ts` to include `destination_location_code: string;`.
2. Modifying `src/hooks/useTripOffers.ts` to correctly populate `flightSearchPayload.destination_location_code` with the value from `currentTripDetails.destination_airport`.

With these changes, the Edge Function now receives the correct destination information, allowing it to find and insert flight offers, which are then fetched and rendered in the UI.