### PR TITLE
Here's my plan for investigating the "Auto-Book" toggle:

### DIFF
--- a/src/components/trip/sections/AutoBookingSection.tsx
+++ b/src/components/trip/sections/AutoBookingSection.tsx
@@ -36,9 +36,11 @@ const AutoBookingSection = ({ control }: AutoBookingSectionProps) => {
   const { toast } = useToast();
 
   const autoBookEnabled = watch("auto_book_enabled");
+  console.log("auto_booking_enabled watched value at definition:", autoBookEnabled);
   const selectedPaymentMethodId = watch("preferred_payment_method_id");
 
   const handleAutoBookToggle = async (enabled: boolean) => {
+    console.log("handleAutoBookToggle called with enabled:", enabled);
     if (enabled) {
       if (isLoadingTravelerInfo || isLoadingPaymentMethods) {
         toast({
@@ -46,6 +48,7 @@ const AutoBookingSection = ({ control }: AutoBookingSectionProps) => {
           description: "Please wait while we verify auto-booking eligibility.",
         });
         setValue("auto_book_enabled", false);
+        console.log("auto_booking_enabled after prerequisites setValue(false):", getValues().auto_book_enabled);
         return;
       }
 
@@ -67,10 +70,12 @@ const AutoBookingSection = ({ control }: AutoBookingSectionProps) => {
           variant: "destructive",
         });
         setValue("auto_book_enabled", false);
+        console.log("auto_booking_enabled after prerequisites setValue(false):", getValues().auto_book_enabled);
         return;
       }
     }
     setValue("auto_book_enabled", enabled, { shouldValidate: true });
+    console.log("auto_booking_enabled after setValue in toggle:", getValues().auto_book_enabled);
   };
 
   const showMissingTravelerInfoAlert = !isLoadingTravelerInfo && !hasTravelerInfo;
@@ -91,11 +96,16 @@ const AutoBookingSection = ({ control }: AutoBookingSectionProps) => {
               </FormDescription>
             </div>
             <FormControl>
+              {(() => { // IIFE to allow statement before expression
+                console.log("auto_booking_enabled field.value before Switch:", field.value);
+                return (
               <Switch
                 checked={field.value}
                 onCheckedChange={handleAutoBookToggle}
                 disabled={isLoadingTravelerInfo || isLoadingPaymentMethods}
               />
+                );
+              })()}
             </FormControl>
           </FormItem>
         )}


### PR DESCRIPTION
I've added some console log statements to help figure out why the "Auto-Book" toggle might not be working as you expect in the TripRequestForm. This is just for tracking things down right now; I haven't made any functional changes.

**Logging I've Added:**

1.  **`src/components/trip/sections/AutoBookingSection.tsx`**:
    *   I'll log the `auto_book_enabled` field value from React Hook Form's `field.value` before the Switch is shown.
    *   I'll log the `watch("auto_book_enabled")` value when the component first loads.
    *   I'll log within `handleAutoBookToggle` to see the `enabled` parameter and the form value after `setValue` is called for `auto_book_enabled`.
    *   These logs will help confirm if the Switch correctly updates the form state within this component.

2.  **`src/components/trip/TripRequestForm.tsx`**:
    *   There was an existing console log (`console.log("Form data before transform:", data);`) in the `onSubmit` function. This will show all form data, including `auto_book_enabled` and `preferred_payment_method_id`, right before it's processed and sent. This helps verify the state of these fields when you submit the form.

**What I Found When Reviewing the Code (Static Analysis):**

*   **`AutoBookingSection.tsx`**: The Switch for `auto_book_enabled` seems to be set up correctly using `field.value` for its `checked` state and `handleAutoBookToggle` (which calls `setValue`) for `onCheckedChange`.
*   **`TripRequestForm.tsx`**:
    *   This form now correctly uses `AutoBookingSection.tsx` (as per a previous fix `fix-auto-booking-payment-method`).
    *   The `auto_book_enabled` field is correctly included in `transformFormData` and in the data sent for `createTripRequest` and `updateTripRequest`.
*   **Zod Schema & Types (`src/types/form.ts`, `src/integrations/supabase/types.ts`)**:
    *   `auto_booking_enabled` is correctly defined as a boolean in the form schema, TypeScript interfaces, and Supabase table type definitions. It doesn't look like it's being removed or mistyped by the schema.

**What I Expect to Happen Based on the Code and Recent Fixes:**

Based on the current codebase (including the fixes from `fix-auto-booking-payment-method` which ensured `AutoBookingSection` is used and its data flows to the backend):
1.  The toggle in `AutoBookingSection` *should* update the `auto_book_enabled` state in React Hook Form. The logs I added in this component will help verify this.
2.  The `onSubmit` in `TripRequestForm` *should* receive the correct `auto_book_enabled` value from the form state. The existing log there will help verify this.
3.  The backend *should* receive `auto_book_enabled: true` if it was enabled in the form.

**Next Steps for Your Investigation (Manual):**

1.  Run the application with these logging changes.
2.  Toggle the "Enable Auto-Booking" switch and select a payment method.
3.  Observe your browser's console logs:
    *   Confirm the logs in `AutoBookingSection.tsx` show `auto_book_enabled` changing from `false` to `true`.
    *   Confirm the log in `TripRequestForm.tsx`'s `onSubmit` shows `auto_book_enabled: true` and the selected `preferred_payment_method_id`.
4.  If the frontend logs look correct, you can then check the network request in your browser's DevTools and then look at the backend (Edge Function logs, database query) as we discussed in the overall investigation plan.

These changes should give you the information needed for the first part of the investigation (the frontend state).