### PR TITLE
chore: Change Vite dev server port to 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "tsc": "tsc",
-    "dev": "vite --port 5173",
+    "dev": "vite --port 3000",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,9 @@ import { componentTagger } from "lovable-tagger";
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
-    host: "::",
-    port: 5173,
+    host: "0.0.0.0",
+    port: 3000,
+    strictPort: true, // Added
   },
   plugins: [
     react(),


### PR DESCRIPTION
This commit updates the Vite development server configuration to use port 3000 instead of 5173.

Changes made:

1.  **`vite.config.ts`**:
    *   Set `server.host` to `"0.0.0.0"`.
    *   Set `server.port` to `3000`.
    *   Added `server.strictPort: true`.

2.  **`package.json`**:
    *   Updated the `scripts.dev` command from `vite --port 5173` to `vite --port 3000`.

These changes align with the requirement to run the development server on `http://localhost:3000/`. You'll need to verify that the application loads on the new port by running `npm run dev`.