### PR TITLE
feat(travelers): expose detailed traveler info status hook

### DIFF
--- a/src/components/TravelerDataForm.tsx
+++ b/src/components/TravelerDataForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useTravelerInfoStatus } from '@/hooks/useTravelerInfoStatus';
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -22,6 +23,8 @@ interface TravelerDataFormProps {
 }
 
 const TravelerDataForm = ({ onSubmit, isLoading = false, initialData = {} }: TravelerDataFormProps) => {
+  const travelerStatus = useTravelerInfoStatus();
+  console.log(travelerStatus);
   const [formData, setFormData] = useState<TravelerData>({
     firstName: initialData.firstName || '',
     lastName: initialData.lastName || '',

--- a/src/hooks/__tests__/useTravelerInfoStatus.test.ts
+++ b/src/hooks/__tests__/useTravelerInfoStatus.test.ts
@@ -1,0 +1,338 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest'; // Import vi from Vitest
+import { useTravelerInfoStatus } from '../useTravelerInfoStatus';
+import { supabase } from '@/integrations/supabase/client';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+
+// Mocking Supabase
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    single: vi.fn(), // This will be configured per test case
+  },
+}));
+
+// Mocking useCurrentUser
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(),
+}));
+
+const mockSupabaseClient = supabase as any; // Cast to any or use Vitest's mocking types if preferred
+const mockUseCurrentUser = useCurrentUser as any; // Cast to any
+
+describe('useTravelerInfoStatus', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks();
+    // Default mock for useCurrentUser, can be overridden in specific tests
+    mockUseCurrentUser.mockReturnValue({ userId: 'test-user-id', user: null, isLoading: false, error: null, fetchUser: vi.fn() });
+  });
+
+  it('should return loading true initially', () => {
+    // Mock Supabase calls for this specific test if needed
+    mockSupabaseClient.from.mockImplementation((tableName: string) => {
+        if (tableName === 'profiles') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockReturnValue(new Promise(() => {})), // Keep it pending
+            } as any;
+        }
+        if (tableName === 'booking_requests') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                not: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockReturnValue(new Promise(() => {})), // Keep it pending
+            } as any;
+        }
+        return { single: vi.fn().mockReturnValue(new Promise(() => {})) } as any;
+    });
+
+    const { result } = renderHook(() => useTravelerInfoStatus());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should handle user not logged in', async () => {
+    mockUseCurrentUser.mockReturnValue({ userId: null, user: null, isLoading: false, error: null, fetchUser: vi.fn() });
+    const { result } = renderHook(() => useTravelerInfoStatus());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.status?.isComplete).toBe(false);
+    expect(result.current.status?.missingFields).toEqual(['userId']);
+    expect(result.current.status?.completionPercentage).toBe(0);
+  });
+
+  it('should calculate status correctly when all data is present', async () => {
+    mockSupabaseClient.from.mockImplementation((tableName: string) => {
+        if (tableName === 'profiles') {
+            return {
+                select: vi.fn((selectString: string) => {
+                    if (selectString === 'email, phone, first_name, last_name') {
+                        return {
+                            eq: vi.fn().mockReturnThis(),
+                            single: vi.fn().mockResolvedValue({
+                                data: { email: 'test@example.com', phone: '1234567890', first_name: 'John', last_name: 'Doe' },
+                                error: null,
+                            }),
+                        };
+                    }
+                    return { eq: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: {}, error: { message: 'Profile select mock not specific enough' }}) };
+                }),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn()
+            } as any;
+        }
+        if (tableName === 'booking_requests') {
+            return {
+                select: vi.fn((selectString: string) => {
+                     if (selectString === 'traveler_data') {
+                         return {
+                            eq: vi.fn().mockReturnThis(),
+                            not: vi.fn().mockReturnThis(),
+                            order: vi.fn().mockReturnThis(),
+                            limit: vi.fn().mockReturnThis(),
+                            single: vi.fn().mockResolvedValue({
+                                data: { traveler_data: { firstName: 'John', lastName: 'Doe', dateOfBirth: '1990-01-01', passportNumber: 'P12345', nationality: 'US', documentExpiryDate: '2030-01-01' } },
+                                error: null,
+                            }),
+                         };
+                     }
+                     return {
+                        eq: vi.fn().mockReturnThis(),
+                        not: vi.fn().mockReturnThis(),
+                        order: vi.fn().mockReturnThis(),
+                        limit: vi.fn().mockReturnThis(),
+                        single: vi.fn().mockResolvedValue({data: {}, error: {message: "Booking request select mock not specific enough"}})
+                    } as any;
+                }),
+                 eq: vi.fn().mockReturnThis(),
+                 not: vi.fn().mockReturnThis(),
+                 order: vi.fn().mockReturnThis(),
+                 limit: vi.fn().mockReturnThis(),
+                 single: vi.fn()
+            } as any;
+        }
+        return {
+            from: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            not: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({data: {}, error: { message: 'Table not mocked'}})
+        } as any;
+    });
+
+    const { result, rerender } = renderHook(() => useTravelerInfoStatus());
+
+    await act(async () => {
+      // No need to call rerender without props change for useEffect to run with renderHook
+      // await for a short period or a condition if necessary, though act should handle promises
+    });
+
+    // It might take a tick for all promises to resolve and state to update
+    // If using older react-testing-library or specific scenarios, waitFor might be needed
+    // For Vitest + RTL 16+, act usually covers it for hook updates.
+
+    await act(async () => {
+        // Ensure all async operations complete
+        // This is a common pattern to ensure state updates from async effects are flushed.
+    });
+
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.status?.isComplete).toBe(true);
+    expect(result.current.status?.missingFields).toEqual([]);
+    expect(result.current.status?.completionPercentage).toBe(100);
+    expect(result.current.status?.requiresInternational).toEqual([]);
+  });
+
+  it('should identify missing passportNumber for international travel', async () => {
+     mockSupabaseClient.from.mockImplementation((tableName: string) => {
+        if (tableName === 'profiles') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { email: 'test@example.com', phone: '1234567890', first_name: 'John', last_name: 'Doe' },
+                    error: null,
+                }),
+            } as any;
+        }
+        if (tableName === 'booking_requests') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                not: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                     data: { traveler_data: { firstName: 'John', lastName: 'Doe', dateOfBirth: '1990-01-01' /* passportNumber is missing */ } },
+                     error: null,
+                }),
+            } as any;
+        }
+        return { single: vi.fn().mockResolvedValue({ data: {}, error: { message: 'Table not mocked', code: 'MOCK_TABLE_ERR'} }) } as any;
+    });
+
+    const { result } = renderHook(() => useTravelerInfoStatus());
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.status?.isComplete).toBe(false);
+    expect(result.current.status?.missingFields).toContain('travelerDetails.passportNumber');
+    expect(result.current.status?.requiresInternational).toContain('travelerDetails.passportNumber');
+    expect(result.current.status?.completionPercentage).toBe(Math.round((6 / 7) * 100)); // Adjusted: 6 completed / 7 total
+  });
+
+  it('should handle profile data missing', async () => {
+    mockSupabaseClient.from.mockImplementation((tableName: string) => {
+        if (tableName === 'profiles') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { email: 'test@example.com' /* first_name, last_name missing */ },
+                    error: null,
+                }),
+            } as any;
+        }
+        if (tableName === 'booking_requests') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                not: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                     data: { traveler_data: { firstName: 'John', lastName: 'Doe', dateOfBirth: '1990-01-01', passportNumber: 'P123' } },
+                     error: null,
+                }),
+            } as any;
+        }
+        return { single: vi.fn().mockResolvedValue({ data: {}, error: { message: 'Table not mocked', code: 'MOCK_TABLE_ERR'} }) } as any;
+    });
+
+    const { result } = renderHook(() => useTravelerInfoStatus());
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.status?.isComplete).toBe(false);
+    expect(result.current.status?.missingFields).toContain('profile.first_name');
+    expect(result.current.status?.missingFields).toContain('profile.last_name');
+    expect(result.current.status?.completionPercentage).toBe(Math.round((5 / 7) * 100)); // Adjusted: 5 completed / 7 total
+  });
+
+  it('should handle traveler_data being null or empty (no booking_request found)', async () => {
+    mockSupabaseClient.from.mockImplementation((tableName: string) => {
+        if (tableName === 'profiles') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({
+                    data: { email: 'test@example.com', first_name: 'John', last_name: 'Doe' },
+                    error: null,
+                }),
+            } as any;
+        }
+        if (tableName === 'booking_requests') {
+            return {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                not: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116', message: 'No rows found'} }),
+            } as any;
+        }
+        return { single: vi.fn().mockResolvedValue({ data: {}, error: { message: 'Table not mocked', code: 'MOCK_TABLE_ERR'} }) } as any;
+    });
+
+    const { result } = renderHook(() => useTravelerInfoStatus());
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.status?.isComplete).toBe(false);
+    expect(result.current.status?.missingFields).toContain('travelerDetails.firstName');
+    expect(result.current.status?.missingFields).toContain('travelerDetails.lastName');
+    expect(result.current.status?.missingFields).toContain('travelerDetails.dateOfBirth');
+    expect(result.current.status?.missingFields).toContain('travelerDetails.passportNumber');
+    expect(result.current.status?.completionPercentage).toBe(Math.round((3 / 7) * 100)); // Adjusted: 3 completed / 7 total
+  });
+
+  it('should handle Supabase errors gracefully when fetching profile', async () => {
+    mockSupabaseClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockRejectedValue(new Error('Supabase network error')),
+        } as any;
+      }
+      if (tableName === 'booking_requests') {
+            return {
+                select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), not: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(), limit: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            } as any;
+        }
+      return { single: vi.fn().mockRejectedValue(new Error("Unknown table error")) } as any;
+    });
+
+    const { result } = renderHook(() => useTravelerInfoStatus());
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error.message).toBe('Supabase network error');
+    expect(result.current.status?.isComplete).toBe(false);
+    expect(result.current.status?.missingFields).toEqual(['fetchError']);
+    expect(result.current.status?.completionPercentage).toBe(0);
+  });
+
+  it('should handle Supabase errors gracefully when fetching traveler_data', async () => {
+    mockSupabaseClient.from.mockImplementation((tableName : string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { email: 'test@example.com', first_name: 'John', last_name: 'Doe' },
+            error: null,
+          }),
+        } as any;
+      }
+      if (tableName === 'booking_requests') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          not: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          single: vi.fn().mockRejectedValue(new Error('Supabase booking_requests error')),
+        } as any;
+      }
+      return { single: vi.fn().mockRejectedValue(new Error("Unknown table error")) } as any;
+    });
+
+    const { result } = renderHook(() => useTravelerInfoStatus());
+     await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error.message).toBe('Supabase booking_requests error');
+    expect(result.current.status?.isComplete).toBe(false);
+    expect(result.current.status?.missingFields).toEqual(['fetchError']);
+    expect(result.current.status?.completionPercentage).toBe(0);
+  });
+
+});

--- a/src/hooks/useTravelerInfoStatus.ts
+++ b/src/hooks/useTravelerInfoStatus.ts
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import type { Database } from '@/integrations/supabase/types';
+
+// Define the shape of the traveler info status
+export type TravelerInfoStatus = {
+  isComplete: boolean;
+  missingFields: string[];
+  completionPercentage: number;
+  requiresInternational: string[]; // Fields required for international travel
+};
+
+// Define the expected structure of traveler_data from booking_requests
+// This should align with what TravelerDataForm collects and what your checks depend on.
+type TravelerDetails = {
+  firstName?: string;
+  lastName?: string;
+  dateOfBirth?: string;
+  gender?: string;
+  passportNumber?: string;
+  // Add other fields that might be part of traveler_data
+  nationality?: string; // Example: important for international checks
+  documentExpiryDate?: string; // Example: important for international checks
+};
+
+
+export const useTravelerInfoStatus = (): { status: TravelerInfoStatus | null; isLoading: boolean; error: any } => {
+  const { userId } = useCurrentUser();
+  const [status, setStatus] = useState<TravelerInfoStatus | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchTravelerInfo = async () => {
+      if (!userId) {
+        setStatus({
+          isComplete: false,
+          missingFields: ['userId'],
+          completionPercentage: 0,
+          requiresInternational: [],
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // 1. Fetch profile data (assuming email and phone are relevant for completion)
+        const { data: profileData, error: profileError } = await supabase
+          .from('profiles')
+          .select('email, phone, first_name, last_name')
+          .eq('id', userId)
+          .single();
+
+        if (profileError) {
+          console.error('Error fetching profile:', profileError);
+          // If profile is crucial and not found, you might want to throw or handle
+        }
+
+        // 2. Fetch traveler details (from booking_requests table, traveler_data column)
+        //    We fetch the most recent booking_request with traveler_data for this user.
+        //    Adjust if traveler details are stored differently (e.g., a dedicated traveler_details table).
+        const { data: travelerRequestData, error: travelerError } = await supabase
+          .from('booking_requests')
+          .select('traveler_data')
+          .eq('user_id', userId)
+          .not('traveler_data', 'is', null)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .single();
+
+        if (travelerError && travelerError.code !== 'PGRST116') { // PGRST116: no rows found, which is a valid case
+          throw travelerError;
+        }
+
+        const travelerDetails: TravelerDetails = travelerRequestData?.traveler_data as TravelerDetails || {};
+        const profile = profileData || {};
+
+        // --- Calculate Status ---
+        const missingFields: string[] = [];
+        const totalFields = 7; // Adjusted to include passportNumber in the core count
+        let completedFields = 0;
+
+        // Profile checks (can be from 'profiles' or 'traveler_details' depending on your data model)
+        if (profile.first_name) completedFields++; else missingFields.push('profile.first_name');
+        if (profile.last_name) completedFields++; else missingFields.push('profile.last_name');
+        if (profile.email) completedFields++; else missingFields.push('profile.email');
+        // if (profile.phone) completedFields++; else missingFields.push('profile.phone');
+
+
+        // TravelerDetails checks (from traveler_data JSON in booking_requests)
+        if (travelerDetails.firstName) completedFields++; else missingFields.push('travelerDetails.firstName');
+        if (travelerDetails.lastName) completedFields++; else missingFields.push('travelerDetails.lastName');
+        if (travelerDetails.dateOfBirth) completedFields++; else missingFields.push('travelerDetails.dateOfBirth');
+        // if (travelerDetails.gender) completedFields++; else missingFields.push('travelerDetails.gender'); // Assuming gender is optional or handled differently
+
+        // International travel specific checks
+        const requiresInternational: string[] = [];
+        if (!travelerDetails.passportNumber) {
+            missingFields.push('travelerDetails.passportNumber');
+            requiresInternational.push('travelerDetails.passportNumber');
+        } else {
+            completedFields++;
+        }
+        // Example: Add more international fields if necessary
+        // if (!travelerDetails.nationality) requiresInternational.push('travelerDetails.nationality');
+        // if (!travelerDetails.documentExpiryDate) requiresInternational.push('travelerDetails.documentExpiryDate');
+
+
+        const completionPercentage = Math.round((completedFields / totalFields) * 100);
+        const isComplete = missingFields.length === 0;
+
+        setStatus({
+          isComplete,
+          missingFields,
+          completionPercentage,
+          requiresInternational,
+        });
+
+      } catch (err) {
+        console.error('Error fetching traveler info status:', err);
+        setError(err);
+        setStatus({ // Provide a default error status
+          isComplete: false,
+          missingFields: ['fetchError'],
+          completionPercentage: 0,
+          requiresInternational: [],
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTravelerInfo();
+  }, [userId]);
+
+  return { status, isLoading, error };
+};


### PR DESCRIPTION
- I created src/hooks/useTravelerInfoStatus.ts to provide detailed traveler information status (isComplete, missingFields, completionPercentage, requiresInternational).
- The hook queries profiles and traveler_details (from booking_requests.traveler_data) to populate this status.
- I updated src/components/TravelerDataForm.tsx to import and call the new hook.
- I added unit tests for the hook in src/hooks/__tests__/useTravelerInfoStatus.test.ts, mocking Supabase and useCurrentUser, and covering various scenarios including international travel checks.
- I corrected totalFields in useTravelerInfoStatus.ts from 6 to 7 based on test findings.