### PR TITLE
I've made several fixes to your tests related to JSDOM, hoisting, and…

### DIFF
--- a/src/tests/components/TripRequestForm.test.tsx
+++ b/src/tests/components/TripRequestForm.test.tsx
@@ -139,6 +139,22 @@ describe('TripRequestForm - Submission Logic', () => {
 
     // Mock navigate
     (useNavigate as vi.Mock).mockReturnValue(vi.fn());
+
+    // Provide default mocks for hooks used by AutoBookingSection for this suite too
+    const mockedUsePaymentMethods = usePaymentMethods as vi.MockedFunction<typeof usePaymentMethods>;
+    const mockedUseTravelerInfoCheck = useTravelerInfoCheck as vi.MockedFunction<typeof useTravelerInfoCheck>;
+
+    mockedUsePaymentMethods.mockReset();
+    mockedUsePaymentMethods.mockReturnValue({
+      data: [{ id: 'pm_1', brand: 'Visa', last4: '4242', is_default: true, nickname: 'Test Card' }],
+      isLoading: false,
+    });
+
+    mockedUseTravelerInfoCheck.mockReset();
+    mockedUseTravelerInfoCheck.mockReturnValue({
+      hasTravelerInfo: true,
+      isLoading: false,
+    });
   });
 
   it('should populate destination_location_code from destination_airport if omitted', async () => {
@@ -189,7 +205,9 @@ describe('TripRequestForm - Submission Logic', () => {
     // DepartureAirportsSection - fill "Other departure airport"
     // It has <Legend>Where are you flying from?</Legend>
     // And an input with placeholder "e.g. SFO, BOS" for other_departure_airport
-    await userEvent.type(screen.getByLabelText(/Other Departure Airport \(IATA code\)/i), 'SFO');
+    const departureAirportInput = screen.getByLabelText(/Other Departure Airport \(IATA code\)/i);
+    departureAirportInput.focus();
+    await userEvent.type(departureAirportInput, 'SFO');
 
     // DateRangeField - "When do you want to travel?"
     // It has two date pickers. Let's assume they have accessible names.
@@ -262,7 +280,9 @@ describe('TripRequestForm - Submission Logic', () => {
 // Helper function to fill the base form fields
 const fillBaseFormFields = async () => {
   await userEvent.type(screen.getByRole('combobox', { name: /destination/i }), 'LAX');
-  await userEvent.type(screen.getByLabelText(/Other Departure Airport \(IATA code\)/i), 'SFO');
+  const departureAirportInput = screen.getByLabelText(/Other Departure Airport \(IATA code\)/i);
+  departureAirportInput.focus();
+  await userEvent.type(departureAirportInput, 'SFO');
   fireEvent.change(screen.getByLabelText(/earliest departure date/i), { target: { value: '2024-10-15' } });
   fireEvent.change(screen.getByLabelText(/latest departure date/i), { target: { value: '2024-10-20' } });
   await userEvent.clear(screen.getByLabelText(/budget/i));

--- a/src/tests/pages/Dashboard.test.tsx
+++ b/src/tests/pages/Dashboard.test.tsx
@@ -157,8 +157,9 @@ describe('Dashboard Page', () => {
     renderDashboardWithRouter();
     await waitFor(() => expect(screen.getByText(`Hello, ${mockUser.email}`)).toBeInTheDocument());
 
+    const user = userEvent.setup();
     const tripHistoryTabTrigger = screen.getByRole('tab', { name: /Trip History/i });
-    await userEvent.click(tripHistoryTabTrigger);
+    await user.click(tripHistoryTabTrigger);
 
     await waitFor(() => {
       // Check if the tab trigger itself believes it's selected
@@ -179,12 +180,13 @@ describe('Dashboard Page', () => {
     renderDashboardWithRouter();
     await waitFor(() => expect(screen.getByText(`Hello, ${mockUser.email}`)).toBeInTheDocument());
 
+    const user = userEvent.setup();
     const tripHistoryTabTrigger = screen.getByRole('tab', { name: /Trip History/i });
-    await userEvent.click(tripHistoryTabTrigger);
+    await user.click(tripHistoryTabTrigger);
     await waitFor(() => expect(screen.getByTestId('trip-history-mock')).toBeInTheDocument());
 
     const currentRequestsTabTrigger = screen.getByRole('tab', { name: /Current Booking Requests/i });
-    await userEvent.click(currentRequestsTabTrigger);
+    await user.click(currentRequestsTabTrigger);
 
     await waitFor(() => expect(screen.getByText(/TestAir TA101/i)).toBeInTheDocument());
     expect(screen.queryByTestId('trip-history-mock')).not.toBeInTheDocument();


### PR DESCRIPTION
… mocks.

Here's what I've completed:
- I enhanced `setupTests.ts` with JSDOM polyfills for PointerEvents, scrollIntoView, ResizeObserver, IntersectionObserver, and matchMedia to improve Radix UI compatibility.
- I corrected `vi.hoisted()` usage for shared toast mocks in `TripConfirm.test.tsx` and `TripRequestForm.test.tsx`, which resolved ReferenceErrors.
- I standardized hook mocking for `usePaymentMethods` and `useTravelerInfoCheck` in the `TripRequestForm.test.tsx` suites, including adding default mocks to the "Submission Logic" suite's `beforeEach`.
- I corrected element selectors in `TripRequestForm.test.tsx`.
- I updated `Dashboard.test.tsx` to use `userEvent.setup().click()` for tab interactions and added an `aria-selected` diagnostic.
- The `flightApi.test.ts` (11 tests) and `TripHistory.test.tsx` (5 tests) suites are now fully passing.
- The "Filter Toggles Logic" suite (4 tests) in `TripRequestForm.test.tsx` is passing.
- Most of `TripConfirm.test.tsx` (2/3 tests) are passing after the hoisting fix.

Here are some pending issues and potential next steps if I were to continue:
- For `TripRequestForm.test.tsx` ("Submission Logic"): I would investigate a potential component rendering failure (empty body output) by ensuring all initial hooks and data are mocked.
- For `TripRequestForm.test.tsx` ("Auto-Booking Logic"): I would address a `pointer-events: none` issue with Radix UI components, possibly by further refining the JSDOM setup, programmatically controlling components, or mocking Radix components.
- For `Dashboard.test.tsx`: I would work on resolving a tab activation failure. If `userEvent.click` remains ineffective, I would try controlling the Tabs component state directly via props.
- For `TripConfirm.test.tsx`: I would diagnose why the booking success toast is not firing, likely by re-verifying Supabase channel event mocks and the component logic for handling these events.