### PR TITLE
I've made some progress on the tests, but there are still some regres…

### DIFF
--- a/src/tests/pages/TripConfirm.test.tsx
+++ b/src/tests/pages/TripConfirm.test.tsx
@@ -216,7 +216,7 @@ describe('TripConfirm Page', () => {
     await waitFor(() => {
       expect(actualMockToastImplementation).toHaveBeenCalledWith(expect.objectContaining({
         title: "Booking Confirmed!",
-        description: "Your trip has been successfully booked. Flight: Flight to Paradise",
+        description: "Your flight has been successfully booked. Redirecting to dashboard...",
       }));
     }, { timeout: 2000 });
   });


### PR DESCRIPTION
…sions, particularly with Radix mocks.

Here's what I've completed:
- Type checking is now passing.
- The `flightApi.test.ts` (11 tests) and `TripHistory.test.tsx` (5 tests) suites are fully passing.
- The "Filter Toggles Logic" suite (4 tests) in `TripRequestForm.test.tsx` is passing.
- I resolved an error in the `TripConfirm.test.tsx` suite by using `vi.hoisted()` for the toast mock (1 out of 3 tests are still failing on logic).
- I enhanced `setupTests.ts` with more JSDOM polyfills (scrollIntoView, simplified pointer events, ResizeObserver, IntersectionObserver, matchMedia).
- I fixed various element selectors and hook mocking strategies in several files.

However, there are some regressions and remaining critical issues:
- In `Dashboard.test.tsx`: My attempt to mock Radix Tabs led to context errors ("TabsList must be used within Tabs"). The tab switching tests (2 out of 5) are failing because the tab state isn't updating on click.
- In `TripRequestForm.test.tsx`:
    - The "Submission Logic" test (1 out of 10) fails with an empty body. This suggests a render crash, possibly due to my attempt to mock Radix Select.
    - The "Auto-Booking Logic" suite (5 out of 10) is failing. Mocking Radix Select (replacing Select with an input) resolved the `pointer-events: none` issue but introduced `getByLabelText` problems because the mocked input isn't labellable.
- In `TripConfirm.test.tsx`: The final test (1 out of 3) for the toast notification on booking success is still failing (the toast is not being called).

If I were to continue, I would focus on these next steps:
- Revert the problematic Radix `Tabs` and `Select` mocks to stabilize rendering.
- For the Dashboard tabs: I would modify the Dashboard component to accept a default active tab prop to make it more testable.
- For the TripRequestForm Radix Select: I would investigate more robust JSDOM workarounds for `pointer-events: none` or consider even more targeted/simplified mocks for Radix primitives if direct interaction remains impossible.
- For the TripRequestForm "Submission Logic" render crash: After reverting the Radix Select mock, I would meticulously check all other initial render dependencies and their mocks.
- For the TripConfirm toast: I would take a closer look at the Supabase channel event mock and the component's event handling logic.