### PR TITLE
feat(flight-search): Refactor date segmentation and add unit tests

### DIFF
--- a/supabase/functions/tests/flightSearch.chunk.test.ts
+++ b/supabase/functions/tests/flightSearch.chunk.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+// Adjust the import path based on the actual location of generateDateSegments if it's not default export or path is different
+import { generateDateSegments } from "../flight-search/index"; // Assuming it's exported from here
+
+describe("generateDateSegments", () => {
+  it("should create correct segments for a range longer than segmentDurationDays", () => {
+    const overallStart = new Date("2024-07-01T00:00:00.000Z");
+    const overallEnd = new Date("2024-08-30T00:00:00.000Z"); // Approx 60 days
+    const segmentDurationDays = 14;
+    const segments = generateDateSegments(overallStart, overallEnd, segmentDurationDays);
+
+    // Expected: 60 days / 14 days/segment = 4 full segments, 1 partial segment of 4 days
+    // (July 1-14, July 15-28, July 29-Aug 11, Aug 12-25, Aug 26-30) -> 5 segments
+    // Let's verify counts and dates carefully.
+    // July: 31 days. August: 31 days.
+    // Segment 1: 2024-07-01 to 2024-07-14 (14 days)
+    // Segment 2: 2024-07-15 to 2024-07-28 (14 days)
+    // Segment 3: 2024-07-29 to 2024-08-11 (14 days)
+    // Segment 4: 2024-08-12 to 2024-08-25 (14 days)
+    // Segment 5: 2024-08-26 to 2024-08-30 (5 days, not 4. Aug 26,27,28,29,30)
+    expect(segments.length).toBe(5);
+
+    // Check first segment
+    expect(segments[0].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-01");
+    expect(segments[0].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-14");
+
+    // Check last segment
+    expect(segments[4].segmentStart.toISOString().slice(0, 10)).toBe("2024-08-26");
+    expect(segments[4].segmentEnd.toISOString().slice(0, 10)).toBe("2024-08-30");
+  });
+
+  it("should create a single segment for a range shorter than segmentDurationDays", () => {
+    const overallStart = new Date("2024-07-01T00:00:00.000Z");
+    const overallEnd = new Date("2024-07-05T00:00:00.000Z"); // 5 days
+    const segmentDurationDays = 14;
+    const segments = generateDateSegments(overallStart, overallEnd, segmentDurationDays);
+
+    expect(segments.length).toBe(1);
+    expect(segments[0].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-01");
+    expect(segments[0].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-05");
+  });
+
+  it("should create correct segments for a range that is an exact multiple of segmentDurationDays", () => {
+    const overallStart = new Date("2024-07-01T00:00:00.000Z");
+    const overallEnd = new Date("2024-07-28T00:00:00.000Z"); // 28 days
+    const segmentDurationDays = 14;
+    const segments = generateDateSegments(overallStart, overallEnd, segmentDurationDays);
+
+    expect(segments.length).toBe(2);
+    expect(segments[0].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-01");
+    expect(segments[0].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-14");
+    expect(segments[1].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-15");
+    expect(segments[1].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-28");
+  });
+
+  it("should handle a single day range correctly", () => {
+    const overallStart = new Date("2024-07-01T00:00:00.000Z");
+    const overallEnd = new Date("2024-07-01T00:00:00.000Z"); // 1 day
+    const segmentDurationDays = 14;
+    const segments = generateDateSegments(overallStart, overallEnd, segmentDurationDays);
+
+    expect(segments.length).toBe(1);
+    expect(segments[0].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-01");
+    expect(segments[0].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-01");
+  });
+
+  it("should handle overallEnd date being before overallStart date (empty array)", () => {
+    const overallStart = new Date("2024-07-10T00:00:00.000Z");
+    const overallEnd = new Date("2024-07-01T00:00:00.000Z");
+    const segmentDurationDays = 14;
+    const segments = generateDateSegments(overallStart, overallEnd, segmentDurationDays);
+    expect(segments.length).toBe(0);
+  });
+
+  it("should handle segmentDurationDays of 1", () => {
+    const overallStart = new Date("2024-07-01T00:00:00.000Z");
+    const overallEnd = new Date("2024-07-03T00:00:00.000Z"); // 3 days
+    const segmentDurationDays = 1;
+    const segments = generateDateSegments(overallStart, overallEnd, segmentDurationDays);
+
+    expect(segments.length).toBe(3);
+    expect(segments[0].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-01");
+    expect(segments[0].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-01");
+    expect(segments[1].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-02");
+    expect(segments[1].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-02");
+    expect(segments[2].segmentStart.toISOString().slice(0, 10)).toBe("2024-07-03");
+    expect(segments[2].segmentEnd.toISOString().slice(0, 10)).toBe("2024-07-03");
+  });
+});


### PR DESCRIPTION
This commit introduces improvements to the date segmentation logic within the `flight-search` Edge Function and adds unit tests for this logic.

Key changes:

1.  **`supabase/functions/flight-search/index.ts`**:
    *   The date range segmentation logic (breaking down a large date window into smaller N-day chunks) has been extracted into an exportable helper function `generateDateSegments`.
    *   The main processing loop now utilizes this helper function to iterate over date segments.
    *   Enhanced logging for the start and end of each segment processing, including the number of offers yielded by each segment.

2.  **`supabase/functions/tests/flightSearch.chunk.test.ts` (New File)**:
    *   Added a new Vitest unit test suite specifically for the `generateDateSegments` helper function.
    *   Includes test cases for various scenarios:
        - Date ranges longer than the segment duration.
        - Date ranges shorter than the segment duration.
        - Date ranges that are exact multiples of the segment duration.
        - Single-day date ranges.
        - Invalid date ranges (end before start).
        - Segment duration of 1 day.
    *   Assertions verify the correct number of segments and the start/end dates of each segment.

These changes make the date segmentation logic more modular, testable, and provide better diagnostic information during its execution.