### PR TITLE
fix(flight-search): Enhance timeout handling and add segment loop safety

### DIFF
--- a/supabase/functions/flight-search/flightApi.edge.ts
+++ b/supabase/functions/flight-search/flightApi.edge.ts
@@ -32,27 +32,36 @@ export async function fetchToken(): Promise<string> {
   const now = Date.now();
   if (_token && now < _tokenExpires - 60_000) return _token;
 
-  const res = await fetchWithTimeout(
-    `${Deno.env.get("AMADEUS_BASE_URL")}/v1/security/oauth2/token`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        grant_type: "client_credentials",
-        client_id: Deno.env.get("AMADEUS_CLIENT_ID")!,
-        client_secret: Deno.env.get("AMADEUS_CLIENT_SECRET")!,
-      }),
-    },
-    8000 // Timeout for token fetch
-  );
+  try {
+    const res = await fetchWithTimeout(
+      `${Deno.env.get("AMADEUS_BASE_URL")}/v1/security/oauth2/token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: Deno.env.get("AMADEUS_CLIENT_ID")!,
+          client_secret: Deno.env.get("AMADEUS_CLIENT_SECRET")!,
+        }),
+      },
+      8000 // Timeout for token fetch
+    );
 
-  if (!res.ok) throw new Error(`Token fetch failed: ${res.status}`);
-  const { access_token, expires_in } = await res.json();
-  _token = access_token;
-  _tokenExpires = now + expires_in * 1000;
-  
-  console.log("[flight-search] Successfully received token");
-  return access_token;
+    if (!res.ok) throw new Error(`Token fetch failed: ${res.status} ${await res.text()}`);
+    const tokenData = await res.json();
+    _token = tokenData.access_token;
+    _tokenExpires = now + tokenData.expires_in * 1000;
+
+    console.log("[flight-search] Successfully received token");
+    return _token!;
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      console.warn(`[flight-search] Timeout during OAuth token fetch.`);
+      throw new Error("Token fetch timed out");
+    }
+    console.error("[flight-search] Error in fetchToken:", err.message);
+    throw err; // Re-throw other errors
+  }
 }
 
 // ——————————————————————————————————————————
@@ -271,44 +280,57 @@ export async function searchOffers(
             travelers: [{ id: "1", travelerType: "ADULT" }],
             sources: ["GDS"]
           };
-          
-          const r = await fetchWithTimeout(url, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(simplePayload),
-          }, 8000); // Timeout for simplified search
-          
-          if (!r.ok) {
-            const errorText = await r.text();
-            throw new Error(`Simplified search error: ${r.status} - ${errorText}`);
+          try {
+            const r = await fetchWithTimeout(url, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(simplePayload),
+            }, 8000); // Timeout for simplified search
+
+            if (!r.ok) {
+              const errorText = await r.text();
+              throw new Error(`Simplified search error: ${r.status} - ${errorText}`);
+            }
+            return await r.json();
+          } catch (err) {
+            if (err.name === 'AbortError') {
+              console.warn(`[flight-search] Timeout during simplified fallback Amadeus call for URL: ${url}`);
+              return { data: [] }; // Return shape expected by withRetry logic
+            }
+            throw err; // Re-throw other errors
           }
-          
-          return await r.json();
         };
         
         const resp = await withRetry(async () => {
-          const r = await fetchWithTimeout(url, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(payload),
-          }, 8000); // Timeout for main search
-          
-          if (!r.ok) {
-            const errorText = await r.text();
-            console.error(`[flight-search] Amadeus API error: ${r.status}`, errorText);
-            throw new Error(`Amadeus API error: ${r.status} - ${errorText}`);
+          try {
+            const r = await fetchWithTimeout(url, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(payload),
+            }, 8000); // Timeout for main search
+
+            if (!r.ok) {
+              const errorText = await r.text();
+              console.error(`[flight-search] Amadeus API error: ${r.status}`, errorText);
+              throw new Error(`Amadeus API error: ${r.status} - ${errorText}`);
+            }
+            return await r.json();
+          } catch (err) {
+            if (err.name === 'AbortError') {
+              console.warn(`[flight-search] Timeout during main Amadeus call for URL: ${url}`);
+              return { data: [] }; // Return shape expected by withRetry logic
+            }
+            throw err; // Re-throw other errors
           }
-          
-          return await r.json();
         }, 3, 500, simplifiedSearch);
         
-        if (resp.data && resp.data.length > 0) {
+        if (resp && resp.data && resp.data.length > 0) { // Added null check for resp
           console.log(`[flight-search] Found ${resp.data.length} raw offers from ${originCode} using strategy ${strategy.name}`);
           // Add all offers from this strategy to our collection
           allRawOffers.push(...resp.data);
@@ -362,23 +384,30 @@ export async function searchOffers(
       const url = `${Deno.env.get("AMADEUS_BASE_URL")}/v2/shopping/flight-offers`;
       
       const resp = await withRetry(async () => {
-        const r = await fetchWithTimeout(url, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(payload),
-        }, 8000); // Timeout for first-tier fallback
-        
-        if (!r.ok) {
-          throw new Error(`Fallback single-origin search failed: ${r.status}`);
+        try {
+          const r = await fetchWithTimeout(url, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }, 8000); // Timeout for first-tier fallback
+
+          if (!r.ok) {
+            throw new Error(`Fallback single-origin search failed: ${r.status} ${await r.text()}`);
+          }
+          return await r.json();
+        } catch (err) {
+          if (err.name === 'AbortError') {
+            console.warn(`[flight-search] Timeout during first-tier fallback Amadeus call for URL: ${url}`);
+            return { data: [] }; // Return shape expected by withRetry logic
+          }
+          throw err; // Re-throw other errors
         }
-        
-        return await r.json();
       });
       
-      if (resp.data && resp.data.length > 0) {
+      if (resp && resp.data && resp.data.length > 0) { // Added null check for resp
         console.log(`[flight-search] Found ${resp.data.length} offers from fallback single-origin search`);
         allRawOffers.push(...resp.data);
       }
@@ -428,28 +457,41 @@ export async function searchOffers(
       const url = `${Deno.env.get("AMADEUS_BASE_URL")}/v2/shopping/flight-offers`;
       console.log("[flight-search] Trying maximally relaxed search criteria with 20% higher budget");
       
-      const resp = await fetchWithTimeout(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(relaxedPayload),
-      }, 8000); // Timeout for second-tier fallback
-      
-      if (!resp.ok) {
-        console.error(`[flight-search] Maximally relaxed search failed: ${resp.status}`);
-      } else {
-        const data = await resp.json();
-        if (data.data && data.data.length > 0) {
-          console.log(`[flight-search] Found ${data.data.length} offers with maximally relaxed criteria`);
-          allRawOffers.push(...data.data);
+      let data: any = { data: [] }; // Default to no data
+      try {
+        const resp = await fetchWithTimeout(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(relaxedPayload),
+        }, 8000); // Timeout for second-tier fallback
+
+        if (resp.ok) {
+          data = await resp.json();
         } else {
-          console.log("[flight-search] No offers found even with maximally relaxed criteria");
+          console.error(`[flight-search] Maximally relaxed search failed (HTTP error): ${resp.status} ${await resp.text()}`);
+          // data remains { data: [] }
         }
+      } catch (err) {
+        if (err.name === 'AbortError') {
+          console.warn(`[flight-search] Timeout during maximally relaxed Amadeus call for URL: ${url}`);
+        } else {
+          // Log other errors but don't necessarily throw, as this is a last-ditch fallback
+          console.error("[flight-search] Error during maximally relaxed Amadeus call:", err);
+        }
+        // data remains { data: [] }, so no offers will be pushed
       }
-    } catch (extremeFallbackError) {
-      console.error("[flight-search] Extreme fallback search failed:", extremeFallbackError);
+
+      if (data.data && data.data.length > 0) {
+        console.log(`[flight-search] Found ${data.data.length} offers with maximally relaxed criteria`);
+        allRawOffers.push(...data.data);
+      } else {
+        console.log("[flight-search] No offers found even with maximally relaxed criteria");
+      }
+    } catch (extremeFallbackError) { // This catch is for errors in setting up relaxedPayload or other logic before fetch
+      console.error("[flight-search] Error in extreme fallback setup:", extremeFallbackError);
     }
   }
     

--- a/supabase/functions/flight-search/index.ts
+++ b/supabase/functions/flight-search/index.ts
@@ -232,6 +232,9 @@ serve(async (req: Request) => {
         const allSegmentOffersRaw: any[] = [];
         const segmentDays = 14;
 
+        let segmentsProcessedCount = 0;
+        const MAX_SEGMENTS_PER_REQUEST = 20; // Limit to prevent excessive segment processing
+
         const dateSegments = generateDateSegments(
           new Date(request.earliest_departure),
           new Date(request.latest_departure),
@@ -241,6 +244,12 @@ serve(async (req: Request) => {
         console.log(`[flight-search] Starting segmented search for request ${request.id} over ${dateSegments.length} segment(s). Overall range: ${request.earliest_departure} to ${request.latest_departure}`);
 
         for (const segment of dateSegments) {
+          segmentsProcessedCount++;
+          if (segmentsProcessedCount > MAX_SEGMENTS_PER_REQUEST) {
+            console.warn(`[flight-search] Exceeded max segments (${MAX_SEGMENTS_PER_REQUEST}) for request ${request.id}. Breaking segment loop for this request.`);
+            break;
+          }
+
           const segmentStartStr = segment.segmentStart.toISOString().slice(0,10);
           const segmentEndStr = segment.segmentEnd.toISOString().slice(0,10);
 


### PR DESCRIPTION
This commit builds upon previous timeout improvements for the `flight-search` Edge Function.

Key changes:

1.  **`supabase/functions/flight-search/flightApi.edge.ts`**:
    *   Wrapped calls to `fetchWithTimeout` (and subsequent `.json()` parsing) within `searchOffers` and `fetchToken` in `try-catch` blocks.
    *   If an `AbortError` (timeout) occurs during Amadeus data calls (e.g., in `searchOffers` or its fallbacks), a warning is logged, and the operation effectively returns an empty list of offers for that attempt. This allows `withRetry` or other fallbacks to proceed.
    *   If `fetchToken` times out, a specific "Token fetch timed out" error is thrown.
    *   Other fetch-related errors now log more context using `res.text()`.

2.  **`supabase/functions/flight-search/index.ts`**:
    *   Added a safety mechanism to the date segment processing loop (`for (const segment of dateSegments)`).
    *   A counter (`segmentsProcessedCount`) tracks the number of segments processed for each trip request.
    *   If this count exceeds `MAX_SEGMENTS_PER_REQUEST` (currently set to 20), a warning is logged, and the segment loop for that particular trip request is terminated with a `break` statement. This prevents potential infinite or excessively long loops due to extremely large date ranges or issues in segment calculation.

These enhancements further improve the resilience and stability of the flight search function when dealing with external API timeouts and processing large date ranges.