### PR TITLE
fix: Align auto-booking schema, RPC variable type, and test data

### DIFF
--- a/supabase/functions/tests/auto-book.test.ts
+++ b/supabase/functions/tests/auto-book.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 // supabase/functions/tests/auto-book.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach, MockedFunction } from 'vitest';
 
@@ -107,8 +108,15 @@ describe('auto-book Integration Tests', () => {
 
   // --- Test Case 1: Successful Flow with Seat Selection ---
   it('should successfully book a flight with seat selection and update database', async () => {
+    const generatedTripId = crypto.randomUUID();
+    const generatedUserId = crypto.randomUUID();
+    const generatedAttemptLockId = crypto.randomUUID();
+    const generatedOfferId = crypto.randomUUID();
+    const generatedOrderId = crypto.randomUUID();
+    const generatedBookingRecId = crypto.randomUUID();
+
     const mockTrip = {
-      id: 'tripSuccess123', user_id: 'user1', payment_intent_id: 'pi_success',
+      id: generatedTripId, user_id: generatedUserId, payment_intent_id: 'pi_success', // payment_intent_id is Stripe specific format
       origin_location_code: 'LHR', destination_location_code: 'JFK',
       departure_date: '2024-12-01', return_date: '2024-12-10', adults: 1, nonstop_required: false,
       max_price: 600, allow_middle_seat: true,
@@ -117,15 +125,15 @@ describe('auto-book Integration Tests', () => {
     const mockRequest = createMockRequest(mockTrip);
 
     // Mock Lock Acquisition
-    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: 'attemptLock1' }, error: null }); // booking_attempts.insert
+    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // booking_attempts.insert
 
     // Mock Amadeus
-    const pricedOfferData = { id: 'offer001', price: { total: '500.00', grandTotal: '500.00' }, flightOffers: [{ price: {total: '500.00', grandTotal: '500.00'}}], itineraries: [{ segments: [{ id: 'seg001' }] }] };
-    mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] });
-    mockAmadeusInstance.shopping.flightOffers.pricing.post.mockResolvedValue({ data: pricedOfferData });
+    const pricedOfferData = { id: generatedOfferId, price: { total: '500.00', grandTotal: '500.00' }, flightOffers: [{ price: {total: '500.00', grandTotal: '500.00'}}], itineraries: [{ segments: [{ id: 'seg001' }] }] };
+    mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] }); // Assuming this is not used directly by auto-book but by priceWithAmadeus
+    mockAmadeusInstance.shopping.flightOffers.pricing.post.mockResolvedValue({ data: pricedOfferData }); // Used by priceWithAmadeus
     const seatMapData = { data: [{ flightSegments: [{ decks: [{ rows: [{ seats: [{ seatNumber: '1A', features: ['AISLE'], pricing: {total: '20.00'}, available: true }] }] }] }] }] };
     mockAmadeusInstance.shopping.seatMaps.get.mockResolvedValue(seatMapData);
-    const bookingConfirmation = { data: { id: 'orderXYZ1', flightOrderId: 'orderXYZ1', associatedRecords: [{reference: 'PNR123'}], flightOffers: [pricedOfferData] }};
+    const bookingConfirmation = { data: { id: generatedOrderId, flightOrderId: generatedOrderId, associatedRecords: [{reference: 'PNR123'}], flightOffers: [pricedOfferData] }};
     mockAmadeusInstance.booking.flightOrders.post.mockResolvedValue(bookingConfirmation);
 
     // Mock selectSeat
@@ -137,48 +145,54 @@ describe('auto-book Integration Tests', () => {
 
     // Mock DB Updates (bookings, trip_requests, booking_attempts)
     (mockSupabaseClientInstance.single as MockedFunction<any>)
-        .mockResolvedValueOnce({ data: { id: 'bookingRec1' }, error: null }) // bookings.update
-        .mockResolvedValueOnce({ data: { id: 'tripSuccess123' }, error: null }) // trip_requests.update
-        .mockResolvedValueOnce({ data: { id: 'attemptLock1' }, error: null }); // booking_attempts.update (finally)
+        .mockResolvedValueOnce({ data: { id: generatedBookingRecId }, error: null }) // bookings.update
+        .mockResolvedValueOnce({ data: { id: generatedTripId }, error: null }) // trip_requests.update
+        .mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // booking_attempts.update (finally)
 
     const response = await autoBookHandler(mockRequest);
     const responseBody = await response.json();
 
     expect(response.status).toBe(200);
     expect(responseBody.success).toBe(true);
-    expect(responseBody.flightOrderId).toBe('orderXYZ1');
+    expect(responseBody.flightOrderId).toBe(generatedOrderId);
     expect(mockSelectSeat).toHaveBeenCalledWith(seatMapData.data[0], 500, 600, true);
 
     const amadeusBookingCall = mockAmadeusInstance.booking.flightOrders.post.mock.calls[0][0];
     expect(JSON.parse(amadeusBookingCall).data.travelers[0].seatSelections).toEqual([{ segmentId: 'seg001', seatNumber: '1A' }]);
 
     expect(mockSupabaseClientInstance.from).toHaveBeenCalledWith('bookings');
-    expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'booked', selected_seat_number: '1A', amadeus_order_id: 'orderXYZ1' }));
+    expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'booked', selected_seat_number: '1A', amadeus_order_id: generatedOrderId }));
     expect(mockSupabaseClientInstance.from).toHaveBeenCalledWith('trip_requests');
     expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ auto_book: false, status: 'booked' }));
     expect(mockSupabaseClientInstance.from).toHaveBeenCalledWith('booking_attempts');
-    expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed', flight_order_id: 'orderXYZ1' }));
+    expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed', flight_order_id: generatedOrderId }));
   });
 
   // --- Test Case 2: Stripe Payment Fails ---
   it('should attempt Amadeus cancellation and update statuses if Stripe payment fails', async () => {
-    const mockTrip = { id: 'tripStripeFail', payment_intent_id: 'pi_stripe_fail', traveler_data: {}, user_id: 'user2' };
-    const mockRequest = createMockRequest(mockTrip);
-    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: 'attemptLock2' }, error: null }); // Lock
+    const generatedTripId = crypto.randomUUID();
+    const generatedUserId = crypto.randomUUID();
+    const generatedAttemptLockId = crypto.randomUUID();
+    const generatedOfferId = crypto.randomUUID();
+    const generatedOrderId = crypto.randomUUID();
 
-    const pricedOfferData = { id: 'offer002', price: { total: '300.00', grandTotal: '300.00' }, flightOffers: [{price: {total: '300.00', grandTotal: '300.00'}}] };
-    mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] });
+    const mockTrip = { id: generatedTripId, payment_intent_id: 'pi_stripe_fail', traveler_data: {}, user_id: generatedUserId };
+    const mockRequest = createMockRequest(mockTrip);
+    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // Lock
+
+    const pricedOfferData = { id: generatedOfferId, price: { total: '300.00', grandTotal: '300.00' }, flightOffers: [{price: {total: '300.00', grandTotal: '300.00'}}] };
+    // mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] }); // Not directly used
     mockAmadeusInstance.shopping.flightOffers.pricing.post.mockResolvedValue({ data: pricedOfferData });
     mockAmadeusInstance.shopping.seatMaps.get.mockResolvedValue({ data: [] }); // No seats
-    const bookingConfirmation = { data: { id: 'orderStripeFail', flightOrderId: 'orderStripeFail', flightOffers: [pricedOfferData] }};
+    const bookingConfirmation = { data: { id: generatedOrderId, flightOrderId: generatedOrderId, flightOffers: [pricedOfferData] }};
     mockAmadeusInstance.booking.flightOrders.post.mockResolvedValue(bookingConfirmation); // Amadeus booking succeeds
 
     mockStripeInstance.paymentIntents.capture.mockRejectedValue(new Error('Stripe Payment Failed')); // Stripe fails
     mockAmadeusInstance.booking.flightOrders.cancel.post.mockResolvedValue({ data: {} }); // Amadeus cancel mock
 
     (mockSupabaseClientInstance.single as MockedFunction<any>)
-        .mockResolvedValueOnce({ data: { id: 'tripStripeFail' }, error: null }) // trip_requests.update (to failed)
-        .mockResolvedValueOnce({ data: { id: 'attemptLock2' }, error: null }); // booking_attempts.update (to failed in finally)
+        .mockResolvedValueOnce({ data: { id: generatedTripId }, error: null }) // trip_requests.update (to failed)
+        .mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // booking_attempts.update (to failed in finally)
 
     const response = await autoBookHandler(mockRequest);
     const responseBody = await response.json();
@@ -186,23 +200,29 @@ describe('auto-book Integration Tests', () => {
     expect(response.status).toBe(500);
     expect(responseBody.success).toBe(false);
     expect(responseBody.error).toContain('Stripe Payment Failed');
-    expect(mockAmadeusInstance.booking.flightOrders.cancel.post).toHaveBeenCalledWith({ path: { flightOrderId: 'orderStripeFail' } });
+    expect(mockAmadeusInstance.booking.flightOrders.cancel.post).toHaveBeenCalledWith({ path: { flightOrderId: generatedOrderId } });
     expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed', auto_book_error: expect.stringContaining('Stripe Payment Failed') })); // trip_requests
     expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed', error_message: expect.stringContaining('Stripe Payment Failed') })); // booking_attempts
   });
 
   // --- Test Case 3: Amadeus Seat Map Fails (Graceful fallback) ---
   it('should proceed with booking if seat map fails, without seat selection', async () => {
-    const mockTrip = { id: 'tripSeatFail', max_price: 400, payment_intent_id: 'pi_seat_fail', traveler_data: {firstName: 'Seat', lastName: 'Fail'}, user_id: 'user3' };
-    const mockRequest = createMockRequest(mockTrip);
-    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: 'attemptLock3' }, error: null }); // Lock
+    const generatedTripId = crypto.randomUUID();
+    const generatedUserId = crypto.randomUUID();
+    const generatedAttemptLockId = crypto.randomUUID();
+    const generatedOfferId = crypto.randomUUID();
+    const generatedOrderId = crypto.randomUUID();
 
-    const pricedOfferData = { id: 'offer003', price: { total: '350.00', grandTotal: '350.00' }, flightOffers: [{price: {total: '350.00', grandTotal: '350.00'}}] };
-    mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] });
+    const mockTrip = { id: generatedTripId, max_price: 400, payment_intent_id: 'pi_seat_fail', traveler_data: {firstName: 'Seat', lastName: 'Fail'}, user_id: generatedUserId };
+    const mockRequest = createMockRequest(mockTrip);
+    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // Lock
+
+    const pricedOfferData = { id: generatedOfferId, price: { total: '350.00', grandTotal: '350.00' }, flightOffers: [{price: {total: '350.00', grandTotal: '350.00'}}] };
+    // mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] });
     mockAmadeusInstance.shopping.flightOffers.pricing.post.mockResolvedValue({ data: pricedOfferData });
     mockAmadeusInstance.shopping.seatMaps.get.mockRejectedValue(new Error('Seat map unavailable')); // Seat map fails
 
-    const bookingConfirmation = { data: { id: 'orderSeatFail', flightOrderId: 'orderSeatFail', flightOffers: [pricedOfferData] }};
+    const bookingConfirmation = { data: { id: generatedOrderId, flightOrderId: generatedOrderId, flightOffers: [pricedOfferData] }};
     mockAmadeusInstance.booking.flightOrders.post.mockResolvedValue(bookingConfirmation);
     mockSelectSeat.mockReturnValue(null); // selectSeat will return null if map fails or no seat found
     mockStripeInstance.paymentIntents.capture.mockResolvedValue({ status: 'succeeded', id: 'pi_seat_fail' });
@@ -217,24 +237,30 @@ describe('auto-book Integration Tests', () => {
 
     expect(response.status).toBe(200);
     expect(responseBody.success).toBe(true);
-    expect(responseBody.flightOrderId).toBe('orderSeatFail');
+    expect(responseBody.flightOrderId).toBe(generatedOrderId);
     const amadeusBookingCall = mockAmadeusInstance.booking.flightOrders.post.mock.calls[0][0];
     expect(JSON.parse(amadeusBookingCall).data.travelers[0].seatSelections).toEqual([]); // No seat selection
     expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'booked', selected_seat_number: null })); // bookings
-    expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed', flight_order_id: 'orderSeatFail' })); // booking_attempts
+    expect(mockSupabaseClientInstance.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed', flight_order_id: generatedOrderId })); // booking_attempts
   });
 
   // --- Test Case 4: DB Update Fails (after successful payment) ---
   it('should return error if DB update fails after payment, without Amadeus rollback', async () => {
-    const mockTrip = { id: 'tripDbFail', payment_intent_id: 'pi_db_fail', traveler_data: {}, user_id: 'user4' };
-    const mockRequest = createMockRequest(mockTrip);
-    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: 'attemptLock4' }, error: null }); // Lock
+    const generatedTripId = crypto.randomUUID();
+    const generatedUserId = crypto.randomUUID();
+    const generatedAttemptLockId = crypto.randomUUID();
+    const generatedOfferId = crypto.randomUUID();
+    const generatedOrderId = crypto.randomUUID();
 
-    const pricedOfferData = { id: 'offer004', price: { total: '200.00', grandTotal: '200.00' }, flightOffers: [{price: {total: '200.00', grandTotal: '200.00'}}] };
-    mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] });
+    const mockTrip = { id: generatedTripId, payment_intent_id: 'pi_db_fail', traveler_data: {}, user_id: generatedUserId };
+    const mockRequest = createMockRequest(mockTrip);
+    (mockSupabaseClientInstance.single as MockedFunction<any>).mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // Lock
+
+    const pricedOfferData = { id: generatedOfferId, price: { total: '200.00', grandTotal: '200.00' }, flightOffers: [{price: {total: '200.00', grandTotal: '200.00'}}] };
+    // mockAmadeusInstance.shopping.flightOffersSearch.get.mockResolvedValue({ data: [pricedOfferData] });
     mockAmadeusInstance.shopping.flightOffers.pricing.post.mockResolvedValue({ data: pricedOfferData });
     mockAmadeusInstance.shopping.seatMaps.get.mockResolvedValue({ data: [] });
-    const bookingConfirmation = { data: { id: 'orderDbFail', flightOrderId: 'orderDbFail', flightOffers: [pricedOfferData] }};
+    const bookingConfirmation = { data: { id: generatedOrderId, flightOrderId: generatedOrderId, flightOffers: [pricedOfferData] }};
     mockAmadeusInstance.booking.flightOrders.post.mockResolvedValue(bookingConfirmation);
     mockStripeInstance.paymentIntents.capture.mockResolvedValue({ status: 'succeeded', id: 'pi_db_fail' }); // Stripe succeeds
 
@@ -242,8 +268,8 @@ describe('auto-book Integration Tests', () => {
     (mockSupabaseClientInstance.single as MockedFunction<any>)
         .mockResolvedValueOnce({ data: null, error: new Error('DB Bookings Update Failed') }); // bookings.update fails
         // trip_requests update might not be reached or also fail
-    (mockSupabaseClientInstance.single as MockedFunction<any>)
-        .mockResolvedValueOnce({ data: { id: 'attemptLock4' }, error: null }); // booking_attempts.update (finally)
+    (mockSupabaseClientInstance.single as MockedFunction<any>) // This is for the booking_attempts update in `finally`
+        .mockResolvedValueOnce({ data: { id: generatedAttemptLockId }, error: null }); // booking_attempts.update (finally)
 
     const response = await autoBookHandler(mockRequest);
     const responseBody = await response.json();
@@ -257,7 +283,10 @@ describe('auto-book Integration Tests', () => {
 
   // --- Test Case 5: Locking Scenario - Idempotency ---
   it('should return 200 if lock acquisition fails with unique constraint (idempotency)', async () => {
-    const mockTrip = { id: 'tripLockFail', user_id: 'user5' };
+    const generatedTripId = crypto.randomUUID();
+    const generatedUserId = crypto.randomUUID();
+
+    const mockTrip = { id: generatedTripId, user_id: generatedUserId };
     const mockRequest = createMockRequest(mockTrip);
 
     // Mock Lock Acquisition Failure (unique violation)

--- a/supabase/migrations/20250611173533_fix_auto_book_schema.sql
+++ b/supabase/migrations/20250611173533_fix_auto_book_schema.sql
@@ -1,0 +1,22 @@
+/* === TRIP_REQUESTS ====================================================== */
+
+ALTER TABLE public.trip_requests
+  ADD COLUMN IF NOT EXISTS origin_location_code TEXT,
+  ADD COLUMN IF NOT EXISTS departure_date DATE,
+  ADD COLUMN IF NOT EXISTS return_date DATE,
+  ADD COLUMN IF NOT EXISTS adults INTEGER DEFAULT 1;
+
+/* rename auto_book_enabled → auto_book (guarded) */
+DO $$
+BEGIN
+  IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='trip_requests' AND column_name='auto_book'
+  )
+  AND EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='trip_requests' AND column_name='auto_book_enabled'
+  ) THEN
+    ALTER TABLE public.trip_requests RENAME COLUMN auto_book_enabled TO auto_book;
+  END IF;
+END $$;

--- a/supabase/migrations/20250611180455_fix_rpc_auto_book_match_var_type.sql
+++ b/supabase/migrations/20250611180455_fix_rpc_auto_book_match_var_type.sql
@@ -1,0 +1,125 @@
+CREATE OR REPLACE FUNCTION "public"."rpc_auto_book_match"("p_booking_request_id" "uuid") RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $_$
+DECLARE
+  v_booking_request public.booking_requests%ROWTYPE;
+  v_offer_data JSONB;
+  v_user_id UUID;
+  v_trip_request_id UUID;
+  v_new_booking_id UUID; -- Changed from BIGINT to UUID
+  v_flight_price NUMERIC;
+  v_airline TEXT;
+  v_flight_number TEXT;
+  v_origin_code TEXT;
+  v_destination_code TEXT;
+  v_notification_message TEXT;
+  v_trip_details RECORD;
+BEGIN
+  -- 1. Fetch the booking_requests row using the UUID parameter
+  SELECT * INTO v_booking_request
+  FROM public.booking_requests
+  WHERE id = p_booking_request_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Booking request with ID % not found', p_booking_request_id;
+  END IF;
+
+  v_offer_data := v_booking_request.offer_data;
+  v_user_id := v_booking_request.user_id;
+  v_trip_request_id := v_booking_request.trip_request_id;
+
+  -- Fetch origin and destination from the associated trip_requests table
+  SELECT origin_location_code, destination_location_code
+  INTO v_trip_details
+  FROM public.trip_requests
+  WHERE id = v_trip_request_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Associated trip request ID % not found for booking request ID %', v_trip_request_id, p_booking_request_id;
+  END IF;
+
+  v_origin_code := v_trip_details.origin_location_code;
+  v_destination_code := v_trip_details.destination_location_code;
+
+  -- Extract details from offer_data for booking and notification
+  v_flight_price := (v_offer_data->>'price')::NUMERIC;
+  v_airline := v_offer_data->>'airline';
+  v_flight_number := v_offer_data->>'flight_number';
+
+  -- 2. Insert into bookings
+  INSERT INTO public.bookings (
+    trip_request_id,
+    user_id,
+    booking_request_id,
+    flight_details,
+    price,
+    source,
+    status,
+    booked_at
+  )
+  VALUES (
+    v_trip_request_id,
+    v_user_id,
+    p_booking_request_id,
+    v_offer_data,
+    v_flight_price,
+    'auto',
+    'booked',
+    NOW()
+  )
+  RETURNING id INTO v_new_booking_id;
+
+  -- 3. Insert into notifications
+  v_notification_message := FORMAT(
+    'We auto-booked your flight from %s to %s with %s (%s) for $%s!',
+    COALESCE(v_origin_code, 'N/A'),
+    COALESCE(v_destination_code, 'N/A'),
+    COALESCE(v_airline, 'N/A'),
+    COALESCE(v_flight_number, 'N/A'),
+    TO_CHAR(v_flight_price, 'FM999,990.00')
+  );
+
+  INSERT INTO public.notifications (
+    user_id,
+    trip_request_id,
+    type,
+    message,
+    data
+  )
+  VALUES (
+    v_user_id,
+    v_trip_request_id,
+    'auto_booking_success',
+    v_notification_message,
+    jsonb_build_object(
+      'booking_id', v_new_booking_id,
+      'booking_request_id', p_booking_request_id,
+      'trip_request_id', v_trip_request_id,
+      'offer_price', v_flight_price,
+      'airline', v_airline,
+      'flight_number', v_flight_number,
+      'origin', v_origin_code,
+      'destination', v_destination_code,
+      'original_offer_data', v_offer_data
+    )
+  );
+
+  -- 4. Update booking_requests.status to 'done'
+  UPDATE public.booking_requests
+  SET status = 'done', updated_at = NOW(), error_message = NULL
+  WHERE id = p_booking_request_id;
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE NOTICE 'Error in rpc_auto_book_match for booking_request_id %: %', p_booking_request_id, SQLERRM;
+    UPDATE public.booking_requests
+    SET status = 'failed', error_message = SQLERRM, updated_at = NOW()
+    WHERE id = p_booking_request_id;
+END;
+$_$;
+
+-- It's good practice to also set the owner of the function,
+-- usually to 'postgres' or the specific role that owns the schema/db.
+-- If the original function had an ALTER FUNCTION ... OWNER TO ... line, replicate it.
+-- Assuming 'postgres' for now if not specified otherwise.
+ALTER FUNCTION "public"."rpc_auto_book_match"("p_booking_request_id" "uuid") OWNER TO "postgres";


### PR DESCRIPTION
This commit addresses several discrepancies to ensure schema and type consistency for the auto-booking feature, based on Phase 1 of your feedback.

Key changes:

1.  **Database Migrations:**
    *   Created `supabase/migrations/20250611173533_fix_auto_book_schema.sql`:
        - Adds columns `origin_location_code TEXT`, `departure_date DATE`, `return_date DATE`, and `adults INTEGER DEFAULT 1` to `public.trip_requests` if they do not already exist.
        - Conditionally renames the `auto_book_enabled` column to `auto_book` on `public.trip_requests` if `auto_book_enabled` exists and `auto_book` does not.
    *   Created `supabase/migrations/20250611180455_fix_rpc_auto_book_match_var_type.sql`:
        - Replaces the `public.rpc_auto_book_match(p_booking_request_id uuid)` function to correct the data type of the internal variable `v_new_booking_id` from `BIGINT` to `UUID`. This aligns the variable with the `id` column type of the `public.bookings` table.

2.  **Edge Function Type Review:**
    *   Reviewed `supabase/functions/scheduler-flight-search/index.ts` and `supabase/functions/auto-book/index.ts`.
    *   Confirmed that these functions already correctly handle UUIDs as strings and do not contain incorrect numeric casting for ID fields or problematic ID type aliases. No changes were made to these files.

3.  **Test File Updates:**
    *   Modified `supabase/functions/tests/auto-book.test.ts`:
        - Added `import crypto from 'crypto';`.
        - Updated mock data and assertions to use dynamically generated string UUIDs (via `crypto.randomUUID()`) for all relevant identifiers (e.g., `booking_request_id`, `trip_request_id`, `user_id`, `offer_id`), replacing previous numeric or hardcoded non-UUID string IDs.

E2E test file updates (`src/tests/e2e/auto-book-flow.spec.ts`) were skipped for this phase as per your clarification (file does not yet exist).