### PR TITLE
chore: Audit and confirm UUID/casting in RPC and Edge Functions

### DIFF
--- a/supabase/functions/auto-book/index.ts
+++ b/supabase/functions/auto-book/index.ts
@@ -406,6 +406,7 @@ Deno.serve(async (req: Request) => {
     const airlinePnr = bookingResult.confirmationNumber || bookingResult.bookingReference; // Define airlinePnr correctly
     // Attempt to get final price from bookingResult.bookingData, fallback to pricedOffer.price.total
     const bookingDataFinalPrice = bookingResult.bookingData?.flightOffers?.[0]?.price?.total || bookingResult.bookingData?.price?.total;
+    // price cast only, not an ID → OK
     const finalPrice = Number(bookingDataFinalPrice || pricedOffer.price?.total);
 
     if (isNaN(finalPrice)) {

--- a/supabase/functions/scheduler-flight-search/index.ts
+++ b/supabase/functions/scheduler-flight-search/index.ts
@@ -1,3 +1,4 @@
+// no numeric ID casts found (validated 2025-06-11)
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 if (!supabaseUrl || !supabaseServiceRoleKey) {

--- a/supabase/functions/tests/auto-book.test.ts
+++ b/supabase/functions/tests/auto-book.test.ts
@@ -1,3 +1,4 @@
+// ✅ All IDs already UUID via Step 1 (validated 2025-06-11)
 import crypto from 'crypto';
 // supabase/functions/tests/auto-book.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach, MockedFunction } from 'vitest';

--- a/supabase/migrations/20250611180455_fix_rpc_auto_book_match_var_type.sql
+++ b/supabase/migrations/20250611180455_fix_rpc_auto_book_match_var_type.sql
@@ -1,3 +1,4 @@
+-- ✅ No ::BIGINT casts found (validated 2025-06-11)
 CREATE OR REPLACE FUNCTION "public"."rpc_auto_book_match"("p_booking_request_id" "uuid") RETURNS "void"
     LANGUAGE "plpgsql" SECURITY DEFINER
     AS $_$


### PR DESCRIPTION
This commit includes audit confirmations for RPC migration and Edge Functions regarding BIGINT casts and numeric conversions of IDs.

Changes:

1.  **`supabase/migrations/20250611180455_fix_rpc_auto_book_match_var_type.sql`**:
    *   Added comment: `-- ✅ No ::BIGINT casts found (validated 2025-06-11)`
    *   Confirmed no `::BIGINT` casts were present in the RPC definition.

2.  **`supabase/functions/auto-book/index.ts`**:
    *   Added comment: `// price cast only, not an ID → OK`
    *   Confirmed that the specific `Number()` call referenced (around line 409) is for a price value, not an ID.

3.  **`supabase/functions/scheduler-flight-search/index.ts`**:
    *   Added comment: `// no numeric ID casts found (validated 2025-06-11)`
    *   Confirmed no incorrect numeric casting of ID fields was found.

These changes verify the state of the codebase regarding these specific casting concerns.