### PR TITLE
feat: Add core frontend infra hooks and utils

### DIFF
--- a/src/hooks/useConstraintState.tsx
+++ b/src/hooks/useConstraintState.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface ConstraintContextValue { // Renamed for clarity from ConstraintContext to avoid conflict
+  budgetMultiplier: number;
+  currentBudget: number;
+  setBudgetMultiplier: (val: number) => void;
+}
+
+const ConstraintCtx = createContext<ConstraintContextValue | undefined>(undefined);
+
+/**
+ * Wrap your app (e.g. in App.tsx) with:
+ * <ConstraintProvider initialBudget={tripRequests.budget}>…</ConstraintProvider>
+ */
+export const ConstraintProvider = ({
+  children,
+  initialBudget,
+}: {
+  children: ReactNode;
+  initialBudget: number; // from trip_requests.budget or user budget
+}) => {
+  const [budgetMultiplier, setBudgetMultiplier] = useState(1);
+  return (
+    <ConstraintCtx.Provider
+      value={{
+        budgetMultiplier,
+        currentBudget: initialBudget * budgetMultiplier,
+        setBudgetMultiplier,
+      }}
+    >
+      {children}
+    </ConstraintCtx.Provider>
+  );
+};
+
+/**
+ * Hook to access budget multiplier state.
+ * Must be used within a ConstraintProvider.
+ */
+export const useConstraintState = (): ConstraintContextValue => { // Ensure return type matches the context value type
+  const ctx = useContext(ConstraintCtx);
+  if (!ctx) {
+    throw new Error(
+      'useConstraintState must be used within a ConstraintProvider'
+    );
+  }
+  return ctx;
+};

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Returns whether the named feature flag is enabled.
+ * Falls back to defaultVal on error or missing table.
+ * ⚠️ Warning: makes a fetch on each mount; caching may be needed later.
+ */
+export const useFeatureFlag = (name: string, defaultVal = false): boolean => {
+  const [enabled, setEnabled] = useState(defaultVal);
+  useEffect(() => {
+    supabase
+      .from('feature_flags')
+      .select('enabled')
+      .eq('name', name)
+      .single()
+      .then(({ data, error }) => {
+        if (error || data?.enabled === undefined) throw error; // Intentionally throw to fall into catch
+        setEnabled(data.enabled);
+      })
+      .catch((err) => { // Catch the error from then() or other errors
+        console.warn(`[useFeatureFlag] Error fetching flag "${name}", falling back to ${defaultVal}. Error:`, err?.message || err);
+        setEnabled(defaultVal);
+      });
+  }, [name, defaultVal]);
+  return enabled;
+};

--- a/src/utils/formatCurrency.ts
+++ b/src/utils/formatCurrency.ts
@@ -1,0 +1,10 @@
+/**
+ * Formats a number as a localized currency string.
+ * Returns 'N/A' for invalid or non-finite inputs.
+ * @param amount Amount in major currency units
+ * @param currency ISO currency code, e.g. 'USD'
+ */
+export const formatCurrency = (amount: number, currency = 'USD'): string => {
+  if (typeof amount !== 'number' || !isFinite(amount)) return 'N/A';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amount);
+};


### PR DESCRIPTION
This commit introduces three core utilities/hooks for frontend infrastructure:

1.  **`src/hooks/useFeatureFlag.ts`**:
    *   Provides a `useFeatureFlag(name: string, defaultVal = false): boolean` hook.
    *   Fetches the status of a named feature flag from the `feature_flags` table via Supabase.
    *   Falls back to `defaultVal` on error or if the flag is not found, logging a warning.
    *   Includes a note about potential future caching needs due to fetching on each mount.

2.  **`src/utils/formatCurrency.ts`**:
    *   Provides a `formatCurrency(amount: number, currency = 'USD'): string` utility function.
    *   Formats a number into a localized currency string (en-US, USD by default).
    *   Returns 'N/A' for invalid or non-finite inputs.

3.  **`src/hooks/useConstraintState.tsx`**:
    *   Provides `ConstraintProvider` and `useConstraintState()` for managing budget constraints.
    *   `ConstraintProvider` takes an `initialBudget` and manages a `budgetMultiplier` state.
    *   `useConstraintState` hook allows components to access `budgetMultiplier`, calculated `currentBudget`, and `setBudgetMultiplier`.
    *   Throws an error if `useConstraintState` is used outside a `ConstraintProvider`.

Storybook configuration was not added as Storybook does not appear to be part of the current project toolchain.

These utilities form a base for upcoming UI features related to feature-gating and dynamic budget display/adjustment.