### PR TITLE
feat(config): Add constraintProfiles.json and type definitions

### DIFF
--- a/src/config/constraintProfiles.json
+++ b/src/config/constraintProfiles.json
@@ -1,0 +1,14 @@
+{
+  "hard": {
+    "stops": 0,
+    "carry_on": true,
+    "price_ceiling": "budget"
+  },
+  "relaxations": [
+    { "stops": 1, "maxLayoverHrs": 3 },
+    { "price_ceiling": "budget * 1.2" },
+    { "price_ceiling": "budget * 1.44" },
+    { "stops": 2 }
+  ],
+  "version": "2025-06-12-v1"
+}

--- a/src/types/constraintProfiles.ts
+++ b/src/types/constraintProfiles.ts
@@ -1,0 +1,25 @@
+export interface HardConstraints {
+  stops: number;
+  carry_on: boolean;
+  price_ceiling: string; // e.g., "budget", "budget * 1.2"
+}
+
+export interface RelaxationStep {
+  stops?: number;
+  maxLayoverHrs?: number;
+  price_ceiling?: string;
+  // Add other potential relaxation fields here if they become apparent
+}
+
+export interface ConstraintProfiles {
+  hard: HardConstraints;
+  relaxations: RelaxationStep[];
+  version: string;
+}
+
+// Optional: If you want to directly import the JSON with types,
+// you might also need a .d.ts file or tsconfig changes for JSON module resolution,
+// but providing the interfaces separately is a good first step for type safety.
+// For example, in code:
+// import profilesData from '@/config/constraintProfiles.json';
+// const profiles: ConstraintProfiles = profilesData;


### PR DESCRIPTION
This commit introduces a configuration file for search constraints and their progressive relaxation, along with corresponding TypeScript type definitions.

New Files:

1.  **`src/config/constraintProfiles.json`**:
    *   Contains the structured JSON data defining:
        -   `hard` constraints (e.g., initial stops, carry-on, price ceiling).
        -   An array of `relaxations` steps (e.g., increasing stops, layover hours, price ceiling multipliers).
        -   A `version` string for the profile set.

2.  **`src/types/constraintProfiles.ts`**:
    *   Provides TypeScript interfaces (`HardConstraints`, `RelaxationStep`, `ConstraintProfiles`) for type-safe consumption of the `constraintProfiles.json` data within the application.

These files establish a single source of truth for search constraint configurations, enabling more manageable and configurable search logic.