### PR TITLE
feat: Add shared offer types and verify backend pool data

### DIFF
--- a/src/types/offer.ts
+++ b/src/types/offer.ts
@@ -1,0 +1,17 @@
+// src/types/offer.ts
+import { Offer as BaseOffer } from '@/services/tripOffersService';
+
+export interface FlightPricing {
+  base: number;
+  carryOnFee: number;
+  total: number;
+}
+
+export interface ScoredOffer extends BaseOffer {
+  price: number;              // legacy for backward-compat
+  priceStructure: FlightPricing;
+  carryOnIncluded: boolean;
+  score: number;
+  reasons: string[];
+  pool: 1 | 2 | 3;
+}


### PR DESCRIPTION
I created `src/types/offer.ts` with `FlightPricing` and `ScoredOffer` interfaces as per your requirements.

I verified that the `supabase/functions/flight-search/flightApi.edge.ts` edge function already returns `poolA`, `poolB`, and `poolC` data. The function structures this in the `SearchOffersResult` type as `pools: { poolA: ScoredOffer[]; poolB: ScoredOffer[]; poolC: ScoredOffer[]; }`. No modifications to the edge function were necessary to meet this part of your requirement.

The `ScoredOffer` interface in `src/types/offer.ts` includes a `pool: 1 | 2 | 3` field, which your client-side logic can use. The edge function's `ScoredOffer` type (internal to it) does not contain this field, as offers are returned in pre-segregated pool arrays.