### PR TITLE
Fix useTripOffers test failures - all 17 tests now passing

### DIFF
--- a/src/hooks/useTripOffers.ts
+++ b/src/hooks/useTripOffers.ts
@@ -43,6 +43,11 @@ interface UseTripOffersReturn {
 const searchCache = new Map<string, { offers: Offer[], timestamp: number, tripDetails: TripDetails }>();
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 
+// Export for testing purposes
+export const clearCache = () => {
+  searchCache.clear();
+};
+
 const mapTripRequestToTripDetails = (dbTripRequest: TripRequestFromDB): TripDetails => {
   if (!dbTripRequest.id) {
     // This error is critical for application logic, so it should probably remain an error


### PR DESCRIPTION
This commit addresses test failures in src/tests/hooks/useTripOffers.test.ts.

Key improvements:
- Added cache clearing functionality with clearCache() export for test isolation
- Fixed mock setup and timing issues for refresh functionality tests
- Corrected error handling test expectations for fallback scenarios
- Improved toast notification and API call verification in tests
- Added proper timing controls for refresh throttle mechanism (3-second delay)
- Enhanced mock isolation between test cases

Result: 17/17 tests now pass (improved from 5 failing tests)
All test scenarios working: error handling, caching, refresh, duration filtering