### PR TITLE
Fix: Resolve TypeScript errors in useTripOffers.test.ts

### DIFF
--- a/src/tests/hooks/useTripOffers.test.ts
+++ b/src/tests/hooks/useTripOffers.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/globals" />
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useTripOffers, TripDetails, clearCache } from '@/hooks/useTripOffers';
@@ -499,7 +500,7 @@ describe('useTripOffers', () => {
       mockTripOffersService.fetchTripOffers.mockClear();
 
       mockTripOffersService.fetchTripOffers.mockResolvedValue(mockOffers);
-      mockFlightSearchApi.invokeFlightSearch.mockResolvedValue(mockFlightSearchResponse);
+      (invokeFlightSearch as vi.Mock).mockResolvedValue(mockFlightSearchResponse);
 
       // Trigger refresh wrapped in act
       await act(async () => {


### PR DESCRIPTION
Adds the /// <reference types="vitest/globals" /> directive to the top of src/tests/hooks/useTripOffers.test.ts to ensure Vitest global types are recognized by TypeScript.

Also corrects a variable reference on line 503 (previously 502) to use the imported 'invokeFlightSearch' directly with a type assertion for mocking, instead of an undefined 'mockFlightSearchApi' object.

These changes address TS2503 "Cannot find namespace 'vi'" errors and ensure the project builds successfully.