### PR TITLE
feat: Implement Flight Search V2 read path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,39 @@ Use these metrics to:
 - Monitor rate limit impacts
 - Ensure the system is performing within expected parameters
 
+### Flight Search v2
+
+A new version of the flight search functionality (V2) is being developed. This version introduces a new data path and user interface for displaying flight offers.
+
+**Key Components:**
+
+*   **`flight_offers_v2` Table:** A new database table to store V2 flight offers.
+*   **`/flight-offers-v2` Edge Function:** Retrieves V2 flight offers based on a `trip_request_id`.
+*   **`flight_search_v2_enabled` Feature Flag:** Controls the availability of the V2 functionality (both in environment variables and the `feature_flags` database table).
+*   **`useFlightOffers` Hook (`src/flightSearchV2/useFlightOffers.ts`):**
+    *   Fetches V2 flight offers via a server action.
+    *   Handles mapping from database schema (snake_case) to application schema (camelCase).
+    *   Includes cancellation-on-unmount and early return if the feature flag is disabled.
+*   **`getFlightOffers` Server Action (`src/serverActions/getFlightOffers.ts`):**
+    *   Calls the `/flight-offers-v2` edge function.
+    *   Implements a 5-minute in-memory cache for results.
+*   **`TripOffersV2.tsx` Page (`src/pages/TripOffersV2.tsx`):**
+    *   A new page that utilizes the `useFlightOffers` hook to display V2 flight offers.
+    *   Includes loading, empty, and error states.
+    *   Shows a placeholder if the V2 feature flag is disabled.
+
+**Testing:**
+
+*   Unit tests for the `getFlightOffers` server action (Vitest, mocked fetch).
+*   Hook tests for `useFlightOffers` (Vitest with RTL, covering success, flag-off, invalid ID, unmount).
+*   Component tests for `TripOffersV2.tsx` (RTL, covering loading, data, empty, and flag-disabled states).
+
+**Accessing V2 Offers:**
+
+*   Navigate to the `/trip/offers-v2` route (exact route might vary depending on router configuration for `TripOffersV2.tsx`).
+*   Ensure the `flight_search_v2_enabled` feature flag is ON in your environment and database.
+*   Ensure there is data in the `flight_offers_v2` table for a given `trip_request_id` that the page will use.
+
 ## Project Structure
 
 - `/src/pages` - Main application pages

--- a/src/flightSearchV2/utils/mapFlightOfferDbRowToV2.ts
+++ b/src/flightSearchV2/utils/mapFlightOfferDbRowToV2.ts
@@ -1,0 +1,26 @@
+import { FlightOfferV2, FlightOfferV2DbRow } from '../types';
+
+/**
+ * Maps a snake_case database row object to a camelCase FlightOfferV2 object.
+ * This function is pure and easily memoizable.
+ * @param dbRow The flight offer data as retrieved from the database.
+ * @returns A FlightOfferV2 object.
+ */
+export const mapFlightOfferDbRowToV2 = (dbRow: FlightOfferV2DbRow): FlightOfferV2 => {
+  return {
+    id: dbRow.id,
+    tripRequestId: dbRow.trip_request_id,
+    mode: dbRow.mode,
+    priceTotal: dbRow.price_total,
+    priceCarryOn: dbRow.price_carry_on,
+    bagsIncluded: dbRow.bags_included,
+    cabinClass: dbRow.cabin_class,
+    nonstop: dbRow.nonstop,
+    originIata: dbRow.origin_iata,
+    destinationIata: dbRow.destination_iata,
+    departDt: dbRow.depart_dt,
+    returnDt: dbRow.return_dt,
+    seatPref: dbRow.seat_pref,
+    createdAt: dbRow.created_at,
+  };
+};

--- a/src/pages/TripOffersV2.test.tsx
+++ b/src/pages/TripOffersV2.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import TripOffersV2 from './TripOffersV2';
+import * as useFlightOffersHook from '@/flightSearchV2/useFlightOffers';
+import { FlightOfferV2 } from '@/flightSearchV2/types';
+
+// Mock the useFlightOffers hook
+vi.mock('@/flightSearchV2/useFlightOffers');
+
+const mockUseFlightOffers = useFlightOffersHook.useFlightOffers as vi.Mock;
+
+const mockOffers: FlightOfferV2[] = [
+  { id: 'offer-1', tripRequestId: 'trip-1', mode: 'AUTO', priceTotal: 199.99, priceCarryOn: 25, bagsIncluded: true, cabinClass: 'ECONOMY', nonstop: true, originIata: 'JFK', destinationIata: 'LAX', departDt: '2024-12-01T10:00:00Z', returnDt: null, seatPref: 'AISLE', createdAt: '2024-07-01T00:00:00Z' },
+  { id: 'offer-2', tripRequestId: 'trip-1', mode: 'MANUAL', priceTotal: 299.50, priceCarryOn: 0, bagsIncluded: false, cabinClass: 'BUSINESS', nonstop: false, originIata: 'SFO', destinationIata: 'MIA', departDt: '2024-12-05T12:30:00Z', returnDt: '2024-12-10T15:00:00Z', seatPref: null, createdAt: '2024-07-02T00:00:00Z' },
+];
+
+const defaultMockReturn = {
+  offers: [],
+  isLoading: false,
+  error: null,
+  isFeatureEnabled: true,
+  refetch: vi.fn(),
+};
+
+describe('TripOffersV2 Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock implementation for each test
+    mockUseFlightOffers.mockReturnValue({ ...defaultMockReturn });
+  });
+
+  it('should display FlagDisabledPlaceholder when feature is not enabled', () => {
+    mockUseFlightOffers.mockReturnValueOnce({ ...defaultMockReturn, isFeatureEnabled: false });
+    render(<TripOffersV2 />);
+    expect(screen.getByText('Feature Disabled')).toBeInTheDocument();
+    expect(screen.getByText(/The Flight Search V2 feature is currently disabled/)).toBeInTheDocument();
+    expect(screen.queryByText('Loading flight offers...')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('should display loading state when isLoading is true and feature is enabled', () => {
+    mockUseFlightOffers.mockReturnValueOnce({ ...defaultMockReturn, isLoading: true, isFeatureEnabled: true });
+    render(<TripOffersV2 />);
+    expect(screen.getByText('Loading flight offers...')).toBeInTheDocument();
+  });
+
+  it('should display error message and retry button when error occurs and feature is enabled', () => {
+    const errorMessage = 'Failed to fetch offers';
+    const refetchMock = vi.fn();
+    mockUseFlightOffers.mockReturnValueOnce({ ...defaultMockReturn, error: new Error(errorMessage), isFeatureEnabled: true, refetch: refetchMock });
+    render(<TripOffersV2 />);
+    expect(screen.getByText('Error Loading Offers')).toBeInTheDocument();
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+
+    const retryButton = screen.getByRole('button', { name: /Retry/i });
+    expect(retryButton).toBeInTheDocument();
+    fireEvent.click(retryButton);
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display "No flight offers found" when no offers and not loading/error, and feature is enabled', () => {
+    mockUseFlightOffers.mockReturnValueOnce({ ...defaultMockReturn, offers: [], isFeatureEnabled: true });
+    render(<TripOffersV2 />);
+    expect(screen.getByText('No flight offers found for this trip request.')).toBeInTheDocument();
+  });
+
+  it('should display table with flight offers when offers are available and feature is enabled', () => {
+    mockUseFlightOffers.mockReturnValueOnce({ ...defaultMockReturn, offers: mockOffers, isFeatureEnabled: true });
+    render(<TripOffersV2 />);
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    // Check for table headers
+    expect(screen.getByRole('columnheader', { name: 'ID' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Total Price' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Origin' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Destination' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Departure' })).toBeInTheDocument();
+
+    // Check for offer data
+    mockOffers.forEach(offer => {
+      expect(screen.getByRole('cell', { name: offer.id })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: `$${offer.priceTotal.toFixed(2)}` })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: offer.originIata })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: offer.destinationIata })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: new Date(offer.departDt).toLocaleString() })).toBeInTheDocument();
+    });
+  });
+
+  it('should call refetch when "Refresh Offers" button is clicked', () => {
+    const refetchMock = vi.fn();
+    mockUseFlightOffers.mockReturnValueOnce({ ...defaultMockReturn, offers: mockOffers, isLoading: false, isFeatureEnabled: true, refetch: refetchMock });
+    const { container } = render(<TripOffersV2 />);
+    const componentQueries = within(container);
+
+    const refreshButton = componentQueries.getByRole('button', { name: /Refresh Offers/i });
+    expect(refreshButton).toBeInTheDocument();
+    fireEvent.click(refreshButton);
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show loading, then data (simulating data fetch lifecycle)', async () => {
+    const refetchMock = vi.fn();
+
+    // Initial: Loading
+    mockUseFlightOffers.mockImplementation(() => ({ ...defaultMockReturn, isLoading: true, isFeatureEnabled: true, refetch: refetchMock }));
+    const { container, rerender } = render(<TripOffersV2 />);
+    let componentQueries = within(container);
+
+    expect(componentQueries.getByText('Loading flight offers...')).toBeInTheDocument();
+
+    // Update: Data loaded
+    mockUseFlightOffers.mockImplementation(() => ({ ...defaultMockReturn, isLoading: false, offers: mockOffers, isFeatureEnabled: true, refetch: refetchMock }));
+    rerender(<TripOffersV2 />);
+    componentQueries = within(container); // Re-scope queries to the updated container
+
+    await waitFor(() => {
+        expect(componentQueries.queryByText('Loading flight offers...')).not.toBeInTheDocument();
+        expect(componentQueries.getByRole('table')).toBeInTheDocument();
+        expect(componentQueries.getByRole('cell', { name: mockOffers[0].id })).toBeInTheDocument();
+    });
+  });
+
+  it('should show loading, then empty state (simulating empty data fetch lifecycle)', async () => {
+    const refetchMock = vi.fn();
+
+    // Initial: Loading
+    mockUseFlightOffers.mockImplementation(() => ({ ...defaultMockReturn, isLoading: true, isFeatureEnabled: true, refetch: refetchMock }));
+    const { container, rerender } = render(<TripOffersV2 />);
+    let componentQueries = within(container);
+
+    expect(componentQueries.getByText('Loading flight offers...')).toBeInTheDocument();
+
+    // Update: Empty data
+    mockUseFlightOffers.mockImplementation(() => ({ ...defaultMockReturn, isLoading: false, offers: [], isFeatureEnabled: true, refetch: refetchMock }));
+    rerender(<TripOffersV2 />);
+    componentQueries = within(container); // Re-scope queries
+
+    await waitFor(() => {
+        expect(componentQueries.queryByText('Loading flight offers...')).not.toBeInTheDocument();
+        expect(componentQueries.getByText('No flight offers found for this trip request.')).toBeInTheDocument();
+    });
+  });
+
+});

--- a/src/pages/TripOffersV2.tsx
+++ b/src/pages/TripOffersV2.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { useFlightOffers } from '@/flightSearchV2/useFlightOffers';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Terminal } from "lucide-react";
+
+// Placeholder for a component to show when the feature flag is disabled
+const FlagDisabledPlaceholder: React.FC = () => (
+  <Alert variant="destructive">
+    <Terminal className="h-4 w-4" />
+    <AlertTitle>Feature Disabled</AlertTitle>
+    <AlertDescription>
+      The Flight Search V2 feature is currently disabled. Please contact support if you believe this is an error.
+    </AlertDescription>
+  </Alert>
+);
+
+// Placeholder for Trip ID - in a real app, this would come from props, context, or URL params
+const MOCK_TRIP_REQUEST_ID = 'default-trip-id'; // TODO: Replace with actual ID source
+
+const TripOffersV2: React.FC = () => {
+  // In a real scenario, tripRequestId would likely come from useParams() or similar
+  const { offers, isLoading, error, isFeatureEnabled, refetch } = useFlightOffers(MOCK_TRIP_REQUEST_ID);
+
+  if (!isFeatureEnabled) {
+    return (
+      <div className="container mx-auto p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Flight Offers V2</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <FlagDisabledPlaceholder />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Flight Offers V2</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading && <p>Loading flight offers...</p>}
+          {error && (
+            <Alert variant="destructive">
+              <Terminal className="h-4 w-4" />
+              <AlertTitle>Error Loading Offers</AlertTitle>
+              <AlertDescription>
+                {error.message || 'An unexpected error occurred.'}
+                <button onClick={refetch} className="ml-2 p-1 border rounded bg-gray-100 hover:bg-gray-200 text-sm">Retry</button>
+              </AlertDescription>
+            </Alert>
+          )}
+          {!isLoading && !error && offers.length === 0 && (
+            <p>No flight offers found for this trip request.</p>
+          )}
+          {!isLoading && !error && offers.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Total Price</TableHead>
+                  <TableHead>Origin</TableHead>
+                  <TableHead>Destination</TableHead>
+                  <TableHead>Departure</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {offers.map((offer) => (
+                  <TableRow key={offer.id}>
+                    <TableCell className="font-medium">{offer.id}</TableCell>
+                    <TableCell>${offer.priceTotal.toFixed(2)}</TableCell>
+                    <TableCell>{offer.originIata}</TableCell>
+                    <TableCell>{offer.destinationIata}</TableCell>
+                    <TableCell>{new Date(offer.departDt).toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          {!isLoading && <button onClick={refetch} className="mt-4 p-2 border rounded bg-blue-500 text-white hover:bg-blue-600">Refresh Offers</button>}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TripOffersV2;

--- a/src/serverActions/getFlightOffers.test.ts
+++ b/src/serverActions/getFlightOffers.test.ts
@@ -1,0 +1,163 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getFlightOffers, clearGetFlightOffersCache } from './getFlightOffers';
+import { supabase } from '@/integrations/supabase/client';
+import { FlightOfferV2DbRow } from '@/flightSearchV2/types';
+
+// Mock the supabase client
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+const mockTripRequestId = 'test-trip-id-123';
+const mockDbRows: FlightOfferV2DbRow[] = [
+  {
+    id: 'offer-1',
+    trip_request_id: mockTripRequestId,
+    mode: 'AUTO',
+    price_total: 100,
+    price_carry_on: 20,
+    bags_included: true,
+    cabin_class: 'ECONOMY',
+    nonstop: true,
+    origin_iata: 'JFK',
+    destination_iata: 'LAX',
+    depart_dt: '2024-12-01T10:00:00Z',
+    return_dt: '2024-12-10T18:00:00Z',
+    seat_pref: 'AISLE',
+    created_at: '2024-07-29T12:00:00Z',
+  },
+];
+
+describe('getFlightOffers server action', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset mocks and cache before each test
+    vi.resetAllMocks();
+    clearGetFlightOffersCache(); // Ensure cache is cleared
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should fetch flight offers successfully from the edge function', async () => {
+    (supabase.functions.invoke as vi.Mock).mockResolvedValueOnce({ data: mockDbRows, error: null });
+
+    const result = await getFlightOffers(mockTripRequestId);
+
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('flight-offers-v2', {
+      body: { tripRequestId: mockTripRequestId },
+    });
+    expect(result).toEqual(mockDbRows);
+  });
+
+  it('should throw an error if the edge function invocation fails', async () => {
+    const errorMessage = 'Edge function invocation failed';
+    (supabase.functions.invoke as vi.Mock).mockResolvedValueOnce({ data: null, error: new Error(errorMessage) });
+
+    await expect(getFlightOffers(mockTripRequestId)).rejects.toThrow(
+      `Failed to fetch flight offers v2: ${errorMessage}`
+    );
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw an error if the edge function returns data with an error property', async () => {
+    const functionErrorMessage = 'Invalid trip ID';
+    (supabase.functions.invoke as vi.Mock).mockResolvedValueOnce({ data: { error: functionErrorMessage }, error: null });
+
+    await expect(getFlightOffers(mockTripRequestId)).rejects.toThrow(
+      `Failed to fetch flight offers v2: ${functionErrorMessage}`
+    );
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw an error for unexpected response structure', async () => {
+    (supabase.functions.invoke as vi.Mock).mockResolvedValueOnce({ data: { message: "weird response" }, error: null });
+
+    await expect(getFlightOffers(mockTripRequestId)).rejects.toThrow(
+      'Unexpected response structure from flight offers v2 function.'
+    );
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use cached data for subsequent calls within cache duration', async () => {
+    (supabase.functions.invoke as vi.Mock).mockResolvedValueOnce({ data: mockDbRows, error: null });
+
+    // First call - should fetch
+    await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+
+    // Second call - should use cache
+    const result = await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1); // Not called again
+    expect(result).toEqual(mockDbRows);
+  });
+
+  it('should fetch new data if cache is expired', async () => {
+    const CACHE_DURATION_MS = 5 * 60 * 1000;
+    (supabase.functions.invoke as vi.Mock)
+      .mockResolvedValueOnce({ data: mockDbRows, error: null }) // First call
+      .mockResolvedValueOnce({ data: [{ ...mockDbRows[0], id: 'offer-2' }], error: null }); // Second call after cache expiry
+
+    // First call
+    await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+
+    // Advance time beyond cache duration
+    vi.advanceTimersByTime(CACHE_DURATION_MS + 1000);
+
+    // Second call - should fetch again
+    const result = await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([{ ...mockDbRows[0], id: 'offer-2' }]);
+  });
+
+  it('should use different cache entries for different tripRequestIds', async () => {
+    const mockTripRequestId2 = 'test-trip-id-456';
+    const mockDbRows2: FlightOfferV2DbRow[] = [{ ...mockDbRows[0], id: 'offer-3', trip_request_id: mockTripRequestId2 }];
+
+    (supabase.functions.invoke as vi.Mock)
+      .mockResolvedValueOnce({ data: mockDbRows, error: null }) // Call for mockTripRequestId
+      .mockResolvedValueOnce({ data: mockDbRows2, error: null }); // Call for mockTripRequestId2
+
+    // Fetch for first ID
+    const result1 = await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+    expect(supabase.functions.invoke).toHaveBeenLastCalledWith('flight-offers-v2', { body: { tripRequestId: mockTripRequestId }});
+    expect(result1).toEqual(mockDbRows);
+
+    // Fetch for second ID
+    const result2 = await getFlightOffers(mockTripRequestId2);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(2);
+    expect(supabase.functions.invoke).toHaveBeenLastCalledWith('flight-offers-v2', { body: { tripRequestId: mockTripRequestId2 }});
+    expect(result2).toEqual(mockDbRows2);
+
+    // Call first ID again, should be cached
+    const result1Cached = await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(2); // Not called again for this ID
+    expect(result1Cached).toEqual(mockDbRows);
+  });
+
+  it('clearGetFlightOffersCache should clear the cache', async () => {
+    (supabase.functions.invoke as vi.Mock)
+      .mockResolvedValueOnce({ data: mockDbRows, error: null }) // First call
+      .mockResolvedValueOnce({ data: [{ ...mockDbRows[0], id: 'offer-new' }], error: null }); // Second call
+
+    // First call - caches data
+    await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(1);
+
+    // Clear the cache
+    clearGetFlightOffersCache();
+
+    // Second call - should fetch again as cache is cleared
+    const result = await getFlightOffers(mockTripRequestId);
+    expect(supabase.functions.invoke).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([{ ...mockDbRows[0], id: 'offer-new' }]);
+  });
+});

--- a/src/serverActions/getFlightOffers.ts
+++ b/src/serverActions/getFlightOffers.ts
@@ -1,0 +1,76 @@
+import { supabase } from '@/integrations/supabase/client';
+import { FlightOfferV2DbRow } from '@/flightSearchV2/types';
+
+const CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry {
+  data: FlightOfferV2DbRow[];
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+interface EdgeFunctionError {
+  error: string;
+}
+
+/**
+ * Server action to fetch flight offers for a given trip request ID.
+ * It calls the 'flight-offers-v2' Supabase edge function.
+ * Implements a 5-minute in-memory cache.
+ *
+ * @param tripRequestId The ID of the trip request.
+ * @returns A promise that resolves to an array of FlightOfferV2DbRow objects.
+ * @throws Will throw an error if the fetch fails or the edge function returns an error.
+ */
+export const getFlightOffers = async (tripRequestId: string): Promise<FlightOfferV2DbRow[]> => {
+  const cachedEntry = cache.get(tripRequestId);
+  if (cachedEntry && (Date.now() - cachedEntry.timestamp < CACHE_DURATION_MS)) {
+    console.log(`[ServerAction/getFlightOffers] Cache hit for tripRequestId: ${tripRequestId}`);
+    return cachedEntry.data;
+  }
+
+  console.log(`[ServerAction/getFlightOffers] Cache miss or stale for tripRequestId: ${tripRequestId}. Fetching...`);
+
+  const { data, error } = await supabase.functions.invoke('flight-offers-v2', {
+    body: { tripRequestId },
+  });
+
+  if (error) {
+    console.error(`[ServerAction/getFlightOffers] Error invoking edge function 'flight-offers-v2' for tripRequestId ${tripRequestId}:`, error);
+    throw new Error(`Failed to fetch flight offers v2: ${error.message}`);
+  }
+
+  // The edge function returns the data directly (which should be FlightOfferV2DbRow[])
+  // or an object with an error property, e.g. { error: "message" }
+  // Supabase client's `invoke` might also wrap this. Let's assume `data` is the array if no `error`.
+  // The edge function can return FlightOfferV2DbRow[] or EdgeFunctionError.
+  // The `error` object from `supabase.functions.invoke` handles network/function-level errors.
+  // The `data` object contains the actual JSON response from the function if the invocation itself was successful.
+
+  if (data) {
+    if (Array.isArray(data)) {
+      // Successfully fetched data
+      cache.set(tripRequestId, { data, timestamp: Date.now() });
+      return data as FlightOfferV2DbRow[];
+    } else if (typeof (data as EdgeFunctionError).error === 'string') {
+      // Edge function returned a structured error like { error: "message" }
+      const functionError = data as EdgeFunctionError;
+      console.error(`[ServerAction/getFlightOffers] Edge function returned an error for tripRequestId ${tripRequestId}:`, functionError.error);
+      throw new Error(`Failed to fetch flight offers v2: ${functionError.error}`);
+    }
+  }
+
+  // If data is null (but no supabase error), or if data is not an array and not a known error structure
+  console.error(`[ServerAction/getFlightOffers] Unexpected response structure from edge function for tripRequestId ${tripRequestId}:`, data);
+  throw new Error('Unexpected response structure from flight offers v2 function.');
+};
+
+/**
+ * Clears the in-memory cache for getFlightOffers.
+ * Primarily useful for testing or specific cache invalidation scenarios.
+ */
+export const clearGetFlightOffersCache = () => {
+  cache.clear();
+  console.log('[ServerAction/getFlightOffers] Cache cleared.');
+};


### PR DESCRIPTION
Implements the core read path for Flight Search V2 functionality.

Key changes:
- Added `useFlightOffers` hook (`src/flightSearchV2/useFlightOffers.ts`) to fetch and manage V2 flight offer data. It incorporates a feature flag (`flight_search_v2_enabled`), calls a server action, maps data, and handles loading/error/cancellation states.
- Created `getFlightOffers` server action (`src/serverActions/getFlightOffers.ts`) that calls the Supabase edge function `/flight-offers-v2` and includes a 5-minute in-memory cache.
- Implemented `mapFlightOfferDbRowToV2` utility (`src/flightSearchV2/utils/mapFlightOfferDbRowToV2.ts`) for data transformation.
- Created `TripOffersV2.tsx` page (`src/pages/TripOffersV2.tsx`) to display V2 offers, utilizing the new hook and handling various UI states (loading, data, empty, error, feature disabled).
- Added comprehensive Vitest unit tests for the server action (mocking fetch/Supabase calls, testing cache) and the `useFlightOffers` hook (mocking dependencies, testing all states including feature flag and cancellation).
- Implemented React Testing Library (RTL) tests for the `TripOffersV2` component, covering all rendering states and interactions.
- Updated `README.md` with a new section describing the Flight Search V2 architecture and components.
- Ensured all new code compiles (`npm run build`) and new tests pass with high coverage.
- Addressed ESLint issues in new/modified files, including `rules-of-hooks` and `no-explicit-any`.