### PR TITLE
chore(ci): guardrails for package manager + PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+Describe the changes and why they’re needed.
+
+## Checklist
+- [ ] Workflows do NOT use pnpm/action-setup (Corepack is used instead)
+- [ ] package.json contains "packageManager": "pnpm@8.15.5"
+- [ ] CI enables Corepack and prepares pnpm from package.json
+- [ ] Auth-sensitive files reviewed if applicable (src/pages/Login.tsx, src/pages/AuthCallback.tsx, src/components/AuthGuard.tsx, src/services/userInitialization.ts)
+- [ ] Tests updated or added as needed (unit/integration/E2E)
+
+## Screenshots/Artifacts (if any)
+
+## Risks and Rollback
+- Risk level: low/medium/high
+- Rollback plan:

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -1,0 +1,29 @@
+name: Policy checks
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  workflow-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Forbid pnpm/action-setup in workflows
+        run: |
+          if grep -R "pnpm/action-setup" -n .github/workflows; then
+            echo "Do not use pnpm/action-setup. Use Corepack (corepack enable + corepack prepare)."
+            exit 1
+          else
+            echo "OK: No pnpm/action-setup usage detected."
+          fi
+
+      - name: Forbid hardcoded pnpm versions in workflows
+        run: |
+          if grep -R -n -E "pnpm@|pnpm-version|setup-pnpm" .github/workflows; then
+            echo "Do not hardcode pnpm versions in workflows. Use package.json packageManager and Corepack."
+            exit 1
+          else
+            echo "OK: No hardcoded pnpm versions found."
+          fi


### PR DESCRIPTION
This PR adds:

- Policy workflow to fail if workflows use pnpm/action-setup or hardcode pnpm versions, ensuring Corepack + packageManager pinning are respected.
- PR template with checklist for auth, workflows, and package manager usage.

Why: Prevent recurring CI breakages due to pnpm version conflicts and improve contributor hygiene.

Notes:
- No app code changes.
- Safe to merge once CI passes.
