### PR TITLE
feat(auth): restore soft-gating (public browse; auth at action time)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,17 +138,13 @@ const App = () => {
                   <Route
                     path="/search"
                     element={
-                      <AuthGuard>
-                        <TripNew />
-                      </AuthGuard>
+                      <TripNew />
                     }
                   />
                   <Route
                     path="/trip/offers"
                     element={
-                      <AuthGuard>
-                        <TripOffers />
-                      </AuthGuard>
+                      <TripOffers />
                     }
                   />
                   <Route
@@ -177,50 +173,38 @@ const App = () => {
                   />
                   <Route path="/trips/:tripId/v2"
                     element={
-                      <AuthGuard>
-                        <TripOffersV2 />
-                      </AuthGuard>
+                      <TripOffersV2 />
                     }
                   />
                   <Route
                     path="/auto-booking"
                     element={
-                      <AuthGuard>
-                        <AutoBookingDashboard />
-                      </AuthGuard>
+                      <AutoBookingDashboard />
                     }
                   />
                   <Route
                     path="/auto-booking/new"
                     element={
-                      <AuthGuard>
-                        <AutoBookingNew />
-                      </AuthGuard>
+                      <AutoBookingNew />
                     }
                   />
                   {/* Duffel Flight Search - Production Ready */}
                   <Route
                     path="/duffel-test"
                     element={
-                      <AuthGuard>
-                        <DuffelTest />
-                      </AuthGuard>
+                      <DuffelTest />
                     }
                   />
                   <Route
                     path="/flight-search"
                     element={
-                      <AuthGuard>
-                        <DuffelTest />
-                      </AuthGuard>
+                      <DuffelTest />
                     }
                   />
                   <Route
                     path="/form-analytics"
                     element={
-                      <AuthGuard>
-                        <FormAnalyticsDashboard />
-                      </AuthGuard>
+                      <FormAnalyticsDashboard />
                     }
                   />
                   {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/lib/auth/ensureAuthenticated.ts
+++ b/src/lib/auth/ensureAuthenticated.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export type EnsureAuthOptions = {
+  returnTo?: string; // explicit returnTo, otherwise computed from window.location
+  silent?: boolean;  // if true, do not show toasts here (leave UX to caller)
+};
+
+/**
+ * Checks for an authenticated session. If absent, stores returnTo and
+ * redirects to /login?returnTo=... . Returns true if authenticated, false otherwise.
+ */
+export async function ensureAuthenticated(opts: EnsureAuthOptions = {}): Promise<boolean> {
+  const { data } = await supabase.auth.getSession();
+  if (data.session) return true;
+
+  // Compute returnTo from current URL if not provided
+  const rt = opts.returnTo || (typeof window !== 'undefined'
+    ? `${window.location.pathname}${window.location.search || ''}${window.location.hash || ''}`
+    : '/');
+
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('returnTo', rt);
+    }
+  } catch {}
+
+  // Navigate to login preserving returnTo
+  const url = `/login?returnTo=${encodeURIComponent(rt)}`;
+  if (typeof window !== 'undefined') {
+    window.location.assign(url);
+  }
+  return false;
+}
+

--- a/src/pages/AutoBookingDashboard.tsx
+++ b/src/pages/AutoBookingDashboard.tsx
@@ -14,6 +14,7 @@ import PageWrapper from "@/components/layout/PageWrapper";
 import { withErrorBoundary } from "@/components/ErrorBoundary";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { AutoBookingFAQDialog } from "@/components/autobooking/AutoBookingFAQDialog";
+import { ensureAuthenticated } from "@/lib/auth/ensureAuthenticated";
 
 function AutoBookingDashboard() {
   const navigate = useNavigate();
@@ -22,7 +23,9 @@ function AutoBookingDashboard() {
 
   // No breadcrumbs needed since this is the main dashboard page
 
-  const handleCreateCampaign = () => {
+  const handleCreateCampaign = async () => {
+    const ok = await ensureAuthenticated();
+    if (!ok) return; // redirected to login
     navigate("/auto-booking/new");
   };
 
@@ -31,6 +34,8 @@ function AutoBookingDashboard() {
   };
 
   const handlePauseCampaign = async (campaignId: string) => {
+    const ok = await ensureAuthenticated();
+    if (!ok) return;
     try {
       await pauseCampaign(campaignId);
       toast({
@@ -47,6 +52,8 @@ function AutoBookingDashboard() {
   };
 
   const handleResumeCampaign = async (campaignId: string) => {
+    const ok = await ensureAuthenticated();
+    if (!ok) return;
     try {
       await resumeCampaign(campaignId);
       toast({
@@ -63,6 +70,8 @@ function AutoBookingDashboard() {
   };
 
   const handleDeleteCampaign = async (campaignId: string) => {
+    const ok = await ensureAuthenticated();
+    if (!ok) return;
     if (window.confirm("Are you sure you want to delete this campaign? This action cannot be undone.")) {
       try {
         await deleteCampaign(campaignId);


### PR DESCRIPTION
- Make browse routes public again (auto-booking, search, trips v2, duffel-test, flight-search, form-analytics)
- Keep sensitive routes guarded (wallet, profile, TripConfirm, /debug/auth)
- Add shared ensureAuthenticated helper for action-time auth gating
- Integrate helper into auto-booking actions (create/pause/resume/delete)

Rationale: restore UX that allows browsing without login and prompt only when taking privileged actions.