### PR TITLE
TripRequestForm analytics (feature-flagged submit events)

### DIFF
--- a/src/lib/analytics/submitEvents.ts
+++ b/src/lib/analytics/submitEvents.ts
@@ -1,0 +1,18 @@
+export type SubmitEventType = 'submit_attempt' | 'submit_success' | 'submit_failure';
+
+export interface SubmitEventPayload {
+  form: 'TripRequestForm';
+  mode: 'manual' | 'auto';
+  errorType?: 'validation' | 'transport' | 'service' | 'unknown';
+}
+
+let emitter: ((type: SubmitEventType, payload: SubmitEventPayload) => void) | null = null;
+
+export function setSubmitEmitter(fn: typeof emitter) {
+  emitter = fn;
+}
+
+export function emitSubmitEvent(type: SubmitEventType, payload: SubmitEventPayload) {
+  if (process.env.VITE_FEATURE_ANALYTICS_SUBMIT !== '1') return; // feature-flag gate
+  if (emitter) emitter(type, payload);
+}

--- a/src/tests/unit/analytics/submitEvents.test.ts
+++ b/src/tests/unit/analytics/submitEvents.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { emitSubmitEvent, setSubmitEmitter, type SubmitEventType } from '@/lib/analytics/submitEvents';
+
+// Temporarily toggle the flag in process.env for test
+const withFlag = (fn: () => void) => {
+  const prev = process.env.VITE_FEATURE_ANALYTICS_SUBMIT;
+  process.env.VITE_FEATURE_ANALYTICS_SUBMIT = '1';
+  try { fn(); } finally { process.env.VITE_FEATURE_ANALYTICS_SUBMIT = prev; }
+};
+
+describe('submitEvents analytics', () => {
+  beforeEach(() => {
+    setSubmitEmitter(null as any);
+  });
+
+  it('emits when flag enabled', () => {
+    withFlag(() => {
+      const spy = vi.fn();
+      setSubmitEmitter(spy as any);
+      emitSubmitEvent('submit_attempt', { form: 'TripRequestForm', mode: 'manual' });
+      expect(spy).toHaveBeenCalledWith('submit_attempt', { form: 'TripRequestForm', mode: 'manual' });
+    });
+  });
+
+  it('does not emit when flag disabled', () => {
+    const spy = vi.fn();
+    setSubmitEmitter(spy as any);
+    emitSubmitEvent('submit_attempt', { form: 'TripRequestForm', mode: 'manual' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds feature-flagged analytics events for TripRequestForm submit lifecycle.

What’s included
- src/lib/analytics/submitEvents.ts: emitSubmitEvent + setSubmitEmitter
- Feature flag gate: VITE_FEATURE_ANALYTICS_SUBMIT = '1' to enable
- Unit tests: src/tests/unit/analytics/submitEvents.test.ts

Notes
- No PII in events
- No production behavior change unless flag is enabled
- Keeps emitting logic injectable via setSubmitEmitter for real analytics backends

Follow-up
- Optionally wire emitSubmitEvent into TripRequestForm submit handler (attempt/success/failure) once the flag is enabled and a backend emitter is provided.