### PR TITLE
TripRequestForm: submit analytics events, bugfix, and test-aligned label

### DIFF
--- a/src/lib/analytics/submitEvents.ts
+++ b/src/lib/analytics/submitEvents.ts
@@ -1,0 +1,18 @@
+export type SubmitEventType = 'submit_attempt' | 'submit_success' | 'submit_failure';
+
+export interface SubmitEventPayload {
+  form: 'TripRequestForm';
+  mode: 'manual' | 'auto';
+  errorType?: 'validation' | 'transport' | 'service' | 'unknown';
+}
+
+let emitter: ((type: SubmitEventType, payload: SubmitEventPayload) => void) | null = null;
+
+export function setSubmitEmitter(fn: typeof emitter) {
+  emitter = fn;
+}
+
+export function emitSubmitEvent(type: SubmitEventType, payload: SubmitEventPayload) {
+  if (process.env.VITE_FEATURE_ANALYTICS_SUBMIT !== '1') return; // feature-flag gate
+  if (emitter) emitter(type, payload);
+}

--- a/src/tests/unit/analytics/submitEvents.test.ts
+++ b/src/tests/unit/analytics/submitEvents.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { emitSubmitEvent, setSubmitEmitter, type SubmitEventType } from '@/lib/analytics/submitEvents';
+
+// Temporarily toggle the flag in process.env for test
+const withFlag = (fn: () => void) => {
+  const prev = process.env.VITE_FEATURE_ANALYTICS_SUBMIT;
+  process.env.VITE_FEATURE_ANALYTICS_SUBMIT = '1';
+  try { fn(); } finally { process.env.VITE_FEATURE_ANALYTICS_SUBMIT = prev; }
+};
+
+describe('submitEvents analytics', () => {
+  beforeEach(() => {
+    setSubmitEmitter(null as any);
+  });
+
+  it('emits when flag enabled', () => {
+    withFlag(() => {
+      const spy = vi.fn();
+      setSubmitEmitter(spy as any);
+      emitSubmitEvent('submit_attempt', { form: 'TripRequestForm', mode: 'manual' });
+      expect(spy).toHaveBeenCalledWith('submit_attempt', { form: 'TripRequestForm', mode: 'manual' });
+    });
+  });
+
+  it('does not emit when flag disabled', () => {
+    const spy = vi.fn();
+    setSubmitEmitter(spy as any);
+    emitSubmitEvent('submit_attempt', { form: 'TripRequestForm', mode: 'manual' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Fix submit handler arrow syntax
- Emit submit_attempt/success/failure events behind VITE_FEATURE_ANALYTICS_SUBMIT
- Standardize auto mode step-1 button to ‘Continue → Pricing’ to match tests

Verified:
- Type-check passes
- TripRequestForm suites pass locally; unrelated suites still have preexisting warnings/failures

Requesting review for Phase 3 analytics wiring and minor UI copy alignment.