### PR TITLE
test(unit): force jsdom env for unit project; stabilize window/localStorage and DOM guards

### DIFF
--- a/src/components/__tests__/LaunchDarklyAuthSync.test.tsx
+++ b/src/components/__tests__/LaunchDarklyAuthSync.test.tsx
@@ -1,6 +1,20 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import { render } from '@testing-library/react';
 import React from 'react';
+
+// Ensure a DOM is available even if environment is misconfigured
+beforeAll(async () => {
+  if (typeof document === 'undefined') {
+    const { JSDOM } = await import('jsdom');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    // @ts-ignore
+    globalThis.window = dom.window;
+    // @ts-ignore
+    globalThis.document = dom.window.document;
+    // @ts-ignore
+    globalThis.navigator = dom.window.navigator;
+  }
+});
 
 const identifyMock = vi.fn();
 

--- a/src/hooks/__tests__/useFormAnalytics.test.ts
+++ b/src/hooks/__tests__/useFormAnalytics.test.ts
@@ -37,7 +37,12 @@ function mockRpcSequence(responses: Array<{ data?: any; error?: any }>) {
 // Helper to flush promises
 const flushPromises = () => new Promise(resolve => queueMicrotask(resolve));
 
-Object.defineProperty(window, 'localStorage', {
+// Ensure jsdom-style globals for tests
+const g: any = globalThis as any;
+if (!g.window) {
+  g.window = {};
+}
+Object.defineProperty(g.window, 'localStorage', {
   value: localStorageMock
 });
 

--- a/tests/unit/hooks/useTripOffers.test.ts
+++ b/tests/unit/hooks/useTripOffers.test.ts
@@ -491,8 +491,8 @@ const { result } = await renderHookAct(() =>
       expect(result.current.errorMessage).toBe('Trip not found');
     });
 
-    it('should handle missing trip ID', () => {
-const { result } = await renderHookAct(() =>
+it('should handle missing trip ID', async () => {
+      const { result } = await renderHookAct(() =>
         useTripOffers({ tripId: '' })
       );
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
       {
         test: {
           name: 'unit',
+          environment: 'jsdom',
           include: [
             'tests/unit/**/*.test.ts?(x)',
             'src/**/__tests__/**/*.test.ts?(x)',


### PR DESCRIPTION
Housekeeping to stabilize the unit harness before resuming phase work:\n\n- Force environment: 'jsdom' explicitly on the unit project in vitest.config.ts.\n- Guard window/localStorage usage in useFormAnalytics.test to avoid window references before env.\n- Ensure DOM availability in LaunchDarklyAuthSync.test with a minimal JSDOM fallback (defensive).\n- Fix remaining async usage in useTripOffers.test for the 'missing trip ID' case.\n\nNo runtime changes, just test harness prep to reduce false negatives in CI and speed iteration for the next phases.